### PR TITLE
Accept '--without-brush' option

### DIFF
--- a/src/grabbing.c
+++ b/src/grabbing.c
@@ -62,7 +62,9 @@ static struct brush_image_t * get_brush_image(char * color) {
 
 	struct brush_image_t *brush_image = NULL;
 
-	if (strcasecmp(color, "red") == 0)
+	if (!color)
+		brush_image = NULL;
+	else if (strcasecmp(color, "red") == 0)
 		brush_image = &brush_image_red;
 	else if (strcasecmp(color, "green") == 0)
 		brush_image = &brush_image_green;

--- a/src/main.c
+++ b/src/main.c
@@ -30,12 +30,15 @@ static void process_arguments(Mygestures * self, int argc, char * const *argv) {
 	static struct option opts[] = { { "help", no_argument, 0, 'h' }, {
 			"daemonize", no_argument, 0, 'z' }, { "button",
 	required_argument, 0, 'b' }, { "color", required_argument, 0, 'c' }, {
+			"without-brush", no_argument, 0, 'w' }, {
 			"device", required_argument, 0, 'd' }, { 0, 0, 0, 0 } };
 
 	/* read params */
 
+	int brush_flag = 0;
+
 	while (1) {
-		opt = getopt_long(argc, argv, "b:c:d:vhlz", opts, NULL);
+		opt = getopt_long(argc, argv, "b:c:d:vhlzw", opts, NULL);
 		if (opt == -1)
 			break;
 
@@ -50,7 +53,21 @@ static void process_arguments(Mygestures * self, int argc, char * const *argv) {
 			break;
 
 		case 'c':
+			if (brush_flag) {
+				printf("'--color' option conflicts with '--without-brush'\n");
+				exit(1);
+			}
 			self->brush_color = strdup(optarg);
+			brush_flag = 1;
+			break;
+
+		case 'w':
+			if (brush_flag) {
+				printf("'--without-brush' option conflicts with '--color'\n");
+				exit(1);
+			}
+			self->brush_color = NULL;
+			brush_flag = 1;
 			break;
 
 		case 'l':


### PR DESCRIPTION
Looks like `--without-brush` parsing was left out. This PR brings it in :)