### PR TITLE
Ignore gestures with modifiers (Alt, Ctrl, Shift)

### DIFF
--- a/src/grabbing.c
+++ b/src/grabbing.c
@@ -226,11 +226,22 @@ void grabbing_xinput_grab_start(Grabber * self) {
 			XIEventMask mask = {
 			XIAllDevices, sizeof(mask_data), mask_data };
 
-			XIGrabModifiers mods = {
-			XIAnyModifier };
+			int nmods = 4;
+			XIGrabModifiers mods[4] = {
+				{ 0, 0 }, // no modifiers
+				{ LockMask, 0 }, // Caps lock
+				{ Mod2Mask, 0 }, // Num lock
+				{ LockMask | Mod2Mask, 0 } // Caps & Num lock
+			};
+
+			if (self->allow_modifiers) {
+				nmods = 1;
+				mods[0].modifiers = XIAnyModifier;
+			}
+
 			int res = XIGrabButton(self->dpy, self->deviceid, self->button,
 					rootwindow, None,
-					GrabModeAsync, GrabModeAsync, False, &mask, 1, &mods);
+					GrabModeAsync, GrabModeAsync, False, &mask, nmods, mods);
 
 		}
 
@@ -694,6 +705,7 @@ Grabber * grabber_new(char * device_name, int button) {
 	Grabber * self = malloc(sizeof(Grabber));
 	bzero(self, sizeof(Grabber));
 
+	self->allow_modifiers = 0;
 	self->fine_direction_sequence = malloc(sizeof(char *) * 30);
 	self->rought_direction_sequence = malloc(sizeof(char *) * 30);
 
@@ -701,6 +713,11 @@ Grabber * grabber_new(char * device_name, int button) {
 	grabber_set_button(self, button);
 
 	return self;
+}
+
+void grabber_allow_modifiers(Grabber* self, int enable)
+{
+	self->allow_modifiers = enable;
 }
 
 char* get_device_name_from_event(Grabber* self, XIDeviceEvent* data) {

--- a/src/grabbing.h
+++ b/src/grabbing.h
@@ -43,6 +43,7 @@ typedef struct {
 	int is_direct_touch;
 
 	int button;
+	int allow_modifiers;
 
 	int started;
 	int verbose;
@@ -83,6 +84,7 @@ void grabbing_end_movement(Grabber * self, int new_x, int new_y,
 void grabber_finalize(Grabber * self);
 void grabber_print_devices(Grabber * self);
 void grabber_set_brush_color(Grabber* self, char * brush_color);
+void grabber_allow_modifiers(Grabber* self, int enable);
 
 #endif /* MYGESTURES_GRABBING_H_ */
 

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@ static void process_arguments(Mygestures * self, int argc, char * const *argv) {
 			"daemonize", no_argument, 0, 'z' }, { "button",
 	required_argument, 0, 'b' }, { "color", required_argument, 0, 'c' }, {
 			"without-brush", no_argument, 0, 'w' }, {
+			"allow-modifiers", no_argument, 0, 'm' }, {
 			"device", required_argument, 0, 'd' }, { 0, 0, 0, 0 } };
 
 	/* read params */
@@ -38,7 +39,7 @@ static void process_arguments(Mygestures * self, int argc, char * const *argv) {
 	int brush_flag = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, "b:c:d:vhlzw", opts, NULL);
+		opt = getopt_long(argc, argv, "b:c:d:vhlzwm", opts, NULL);
 		if (opt == -1)
 			break;
 
@@ -50,6 +51,10 @@ static void process_arguments(Mygestures * self, int argc, char * const *argv) {
 
 		case 'b':
 			self->trigger_button = atoi(optarg);
+			break;
+
+		case 'm':
+			self->allow_modifiers = 1;
 			break;
 
 		case 'c':

--- a/src/mygestures.c
+++ b/src/mygestures.c
@@ -53,6 +53,7 @@ void mygestures_usage(Mygestures * self) {
 	printf(" -b, --button <BUTTON>      : Button used to draw the gesture\n");
 	printf("                              Default: '1' on touchscreens,\n");
 	printf("                                       '3' on other pointer dev\n");
+	printf(" -m, --allow-modifiers      : Allow holding modifier keys when drawing the gesture.\n");
 	printf(" -d, --device <DEVICENAME>  : Device to grab.\n");
 	printf(
 			"                              Defaults: 'Virtual core pointer' & 'synaptics'\n");
@@ -74,6 +75,7 @@ Mygestures * mygestures_new() {
 	Mygestures *self = malloc(sizeof(Mygestures));
 	bzero(self, sizeof(Mygestures));
 
+	self->allow_modifiers = 0;
 	self->brush_color = "blue";
 	self->device_list = malloc(sizeof(uint) * MAX_GRABBED_DEVICES);
 	self->gestures_configuration = NULL;
@@ -113,6 +115,7 @@ void mygestures_grab_device(Mygestures* self, char* device_name) {
 		Grabber* grabber = grabber_new(device_name, self->trigger_button);
 
 		grabber_set_brush_color(grabber, self->brush_color);
+		grabber_allow_modifiers(grabber, self->allow_modifiers);
 
 		send_kill_message(device_name);
 

--- a/src/mygestures.h
+++ b/src/mygestures.h
@@ -9,6 +9,7 @@
 typedef struct mygestures_ {
 	int help_flag;
 	int trigger_button;
+	int allow_modifiers;
 	int damonize_option;
 	int list_devices_flag;
 


### PR DESCRIPTION
I have a problem that I'm not able to pan and resize windows in my window manager (<kbd>Alt</kbd>+<kbd>Button1</kbd> and <kbd>Alt</kbd>+<kbd>Button3</kbd>) as it conflicts with MyGestures.

This PR will allow to skip gesture recognition when <kbd>Alt</kbd>, <kbd>Ctrl</kbd> or <kbd>Shift</kbd> is being held.

Basically, instead of grabbing the key with any or no modifiers (`XIAnyModifier`), it will grab only with no modifiers (`0`) or Caps lock (`LockMask`) or Num lock (`Mod2Mask`) or both at the same time (`LockMask | Mod2Mask`).