### PR TITLE
New '--follow-pointer' option

### DIFF
--- a/src/grabbing.h
+++ b/src/grabbing.h
@@ -44,6 +44,7 @@ typedef struct {
 
 	int button;
 	int allow_modifiers;
+	int follow_pointer;
 
 	int started;
 	int verbose;
@@ -85,6 +86,7 @@ void grabber_finalize(Grabber * self);
 void grabber_print_devices(Grabber * self);
 void grabber_set_brush_color(Grabber* self, char * brush_color);
 void grabber_allow_modifiers(Grabber* self, int enable);
+void grabber_follow_pointer(Grabber* self, int enable);
 
 #endif /* MYGESTURES_GRABBING_H_ */
 

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,7 @@ static void process_arguments(Mygestures * self, int argc, char * const *argv) {
 	required_argument, 0, 'b' }, { "color", required_argument, 0, 'c' }, {
 			"without-brush", no_argument, 0, 'w' }, {
 			"allow-modifiers", no_argument, 0, 'm' }, {
+			"follow-pointer", no_argument, 0, 'f' }, {
 			"device", required_argument, 0, 'd' }, { 0, 0, 0, 0 } };
 
 	/* read params */
@@ -39,7 +40,7 @@ static void process_arguments(Mygestures * self, int argc, char * const *argv) {
 	int brush_flag = 0;
 
 	while (1) {
-		opt = getopt_long(argc, argv, "b:c:d:vhlzwm", opts, NULL);
+		opt = getopt_long(argc, argv, "b:c:d:vhlzwmf", opts, NULL);
 		if (opt == -1)
 			break;
 
@@ -55,6 +56,10 @@ static void process_arguments(Mygestures * self, int argc, char * const *argv) {
 
 		case 'm':
 			self->allow_modifiers = 1;
+			break;
+
+		case 'f':
+			self->follow_pointer = 1;
 			break;
 
 		case 'c':

--- a/src/mygestures.c
+++ b/src/mygestures.c
@@ -54,6 +54,7 @@ void mygestures_usage(Mygestures * self) {
 	printf("                              Default: '1' on touchscreens,\n");
 	printf("                                       '3' on other pointer dev\n");
 	printf(" -m, --allow-modifiers      : Allow holding modifier keys when drawing the gesture.\n");
+	printf(" -f, --follow-pointer       : Perform the gesture against the window under pointer.\n");
 	printf(" -d, --device <DEVICENAME>  : Device to grab.\n");
 	printf(
 			"                              Defaults: 'Virtual core pointer' & 'synaptics'\n");
@@ -75,6 +76,7 @@ Mygestures * mygestures_new() {
 	Mygestures *self = malloc(sizeof(Mygestures));
 	bzero(self, sizeof(Mygestures));
 
+	self->follow_pointer = 0;
 	self->allow_modifiers = 0;
 	self->brush_color = "blue";
 	self->device_list = malloc(sizeof(uint) * MAX_GRABBED_DEVICES);
@@ -116,6 +118,7 @@ void mygestures_grab_device(Mygestures* self, char* device_name) {
 
 		grabber_set_brush_color(grabber, self->brush_color);
 		grabber_allow_modifiers(grabber, self->allow_modifiers);
+		grabber_follow_pointer(grabber, self->follow_pointer);
 
 		send_kill_message(device_name);
 

--- a/src/mygestures.h
+++ b/src/mygestures.h
@@ -10,6 +10,7 @@ typedef struct mygestures_ {
 	int help_flag;
 	int trigger_button;
 	int allow_modifiers;
+	int follow_pointer;
 	int damonize_option;
 	int list_devices_flag;
 


### PR DESCRIPTION
I struggle a bit when the gesture performs on the focused window instead of the one under mouse pointer.

When `--follow-pointer` used, it temporally focuses the window under pointer and restores the focus to previous window back when finished.

I'm not sure if you depend on the old behavior, so I just added a new option. Otherwise I can remove the option and make it the new default.