### PR TITLE
Refactor codebase using idiomatic rust practices based on clippy suggestions

### DIFF
--- a/src/bin/gestos.rs
+++ b/src/bin/gestos.rs
@@ -1,11 +1,11 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::process::Command;
-use gtk4 as gtk;
 use gtk::prelude::*;
-use gtk::{cairo, glib, gdk, gio};
-use mygestures::config::{Configuration, Gesture, ActionType, generate_unique_id};
-use mygestures::protractor::{Point2D, match_gesture};
+use gtk::{cairo, gdk, gio, glib};
+use gtk4 as gtk;
+use mygestures::config::{generate_unique_id, ActionType, Configuration, Gesture};
+use mygestures::protractor::{match_gesture, Point2D};
+use std::cell::RefCell;
+use std::process::Command;
+use std::rc::Rc;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -54,7 +54,6 @@ fn get_static_action_options() -> Vec<EditorActionOption> {
             name: "Keypress Shortcut".to_string(),
             tooltip: "Simulate keys like Control_L+Alt_L+t".to_string(),
         },
-        
         // Window Management (1)
         EditorActionOption {
             category: 1,
@@ -110,7 +109,6 @@ fn get_static_action_options() -> Vec<EditorActionOption> {
             name: "Show Desktop".to_string(),
             tooltip: "Minimize all windows or toggle show desktop".to_string(),
         },
-
         // Workspaces & Overview (2)
         EditorActionOption {
             category: 2,
@@ -148,7 +146,6 @@ fn get_static_action_options() -> Vec<EditorActionOption> {
             name: "Show App Grid".to_string(),
             tooltip: "Toggle applications menu/grid".to_string(),
         },
-
         // Media & Audio (3)
         EditorActionOption {
             category: 3,
@@ -186,7 +183,6 @@ fn get_static_action_options() -> Vec<EditorActionOption> {
             name: "Previous Track".to_string(),
             tooltip: "Skip to previous track".to_string(),
         },
-
         // System & Settings (4)
         EditorActionOption {
             category: 4,
@@ -230,7 +226,6 @@ fn get_static_action_options() -> Vec<EditorActionOption> {
             name: "Screenshot Area".to_string(),
             tooltip: "Take screenshot of selection area".to_string(),
         },
-
         // Applications (5)
         EditorActionOption {
             category: 5,
@@ -262,7 +257,6 @@ fn get_static_action_options() -> Vec<EditorActionOption> {
             name: "Calculator".to_string(),
             tooltip: "Open calculator application".to_string(),
         },
-
         // Other/Internal (7)
         EditorActionOption {
             category: 7,
@@ -300,7 +294,10 @@ fn fetch_gnome_action_options() -> Vec<EditorActionOption> {
         let schema = match source.lookup(schema_id, true) {
             Some(s) => s,
             None => {
-                eprintln!("Info: GSettings schema '{}' not found, skipping.", schema_id);
+                eprintln!(
+                    "Info: GSettings schema '{}' not found, skipping.",
+                    schema_id
+                );
                 continue;
             }
         };
@@ -311,7 +308,10 @@ fn fetch_gnome_action_options() -> Vec<EditorActionOption> {
             let skey = schema.key(&key);
             let mut summary = skey.summary().map(|s| s.to_string()).unwrap_or_default();
             if summary.is_empty() {
-                summary = skey.description().map(|s| s.to_string()).unwrap_or_default();
+                summary = skey
+                    .description()
+                    .map(|s| s.to_string())
+                    .unwrap_or_default();
             }
             if summary.is_empty() {
                 summary = key.to_string();
@@ -342,28 +342,34 @@ fn fetch_gnome_action_options() -> Vec<EditorActionOption> {
         }
 
         // Handle custom keybindings
-        if schema_id == "org.gnome.settings-daemon.plugins.media-keys" {
-            if schema.has_key("custom-keybindings") {
-                let paths: Vec<String> = settings.get("custom-keybindings");
-                for path in paths {
-                    let custom = gio::Settings::with_path("org.gnome.settings-daemon.plugins.media-keys.custom-keybinding", &path);
-                    let c_name: String = custom.get("name");
-                    let c_cmd: String = custom.get("command");
+        if schema_id == "org.gnome.settings-daemon.plugins.media-keys"
+            && schema.has_key("custom-keybindings")
+        {
+            let paths: Vec<String> = settings.get("custom-keybindings");
+            for path in paths {
+                let custom = gio::Settings::with_path(
+                    "org.gnome.settings-daemon.plugins.media-keys.custom-keybinding",
+                    &path,
+                );
+                let c_name: String = custom.get("name");
+                let c_cmd: String = custom.get("command");
 
-                    if !c_name.is_empty() {
-                        options.push(EditorActionOption {
-                            category: 6, // CAT_GNOME
-                            action_type: ActionType::Execute(c_cmd.clone()),
-                            name: c_name,
-                            tooltip: format!("Custom GNOME shortcut: {}", c_cmd),
-                        });
-                    }
+                if !c_name.is_empty() {
+                    options.push(EditorActionOption {
+                        category: 6, // CAT_GNOME
+                        action_type: ActionType::Execute(c_cmd.clone()),
+                        name: c_name,
+                        tooltip: format!("Custom GNOME shortcut: {}", c_cmd),
+                    });
                 }
             }
         }
     }
 
-    println!("Fetched {} GNOME action options from GSettings.", options.len());
+    println!(
+        "Fetched {} GNOME action options from GSettings.",
+        options.len()
+    );
     options
 }
 
@@ -380,7 +386,7 @@ struct AppState {
 
 fn is_daemon_running(conn: Option<&zbus::blocking::Connection>) -> bool {
     let dbus_name = mygestures::config::get_dbus_name();
-    
+
     let check_status = |c: &zbus::blocking::Connection| -> Option<bool> {
         let dbus_proxy = zbus::blocking::fdo::DBusProxy::new(c).ok()?;
         let bus_name = zbus::names::BusName::try_from(dbus_name.clone()).ok()?;
@@ -392,7 +398,7 @@ fn is_daemon_running(conn: Option<&zbus::blocking::Connection>) -> bool {
             return running;
         }
     }
-    
+
     if let Ok(new_conn) = zbus::blocking::Connection::session() {
         if let Some(running) = check_status(&new_conn) {
             return running;
@@ -444,7 +450,7 @@ fn show_error_dialog<W: IsA<gtk::Window>>(parent: &W, message: &str) {
     button_box.set_halign(gtk::Align::End);
     let ok_button = gtk::Button::with_label("OK");
     ok_button.set_width_request(80);
-    
+
     let dialog_clone = dialog.clone();
     ok_button.connect_clicked(move |_| {
         dialog_clone.destroy();
@@ -467,16 +473,16 @@ fn start_daemon(conn: Option<&zbus::blocking::Connection>) -> Result<(), String>
     } else {
         "mygestures"
     };
-    
+
     // Spawn the daemon process and pipe stderr
     let mut child = Command::new(cmd)
         .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| format!("Failed to spawn daemon: {}", e))?;
-        
+
     // Wait a short duration to see if the process exits immediately
     std::thread::sleep(std::time::Duration::from_millis(300));
-    
+
     match child.try_wait() {
         Ok(Some(status)) => {
             // Process has exited, read stderr
@@ -502,9 +508,7 @@ fn start_daemon(conn: Option<&zbus::blocking::Connection>) -> Result<(), String>
             }
             Ok(())
         }
-        Err(e) => {
-            Err(format!("Failed to query daemon status: {}", e))
-        }
+        Err(e) => Err(format!("Failed to query daemon status: {}", e)),
     }
 }
 
@@ -512,10 +516,20 @@ fn stop_daemon(conn: Option<&zbus::blocking::Connection>) {
     let dbus_name = mygestures::config::get_dbus_name();
     let stop_via_dbus = || -> zbus::Result<()> {
         let proxy = if let Some(c) = conn {
-            zbus::blocking::Proxy::new(c, dbus_name.clone(), "/org/mygestures/Daemon", "org.mygestures.Daemon")
+            zbus::blocking::Proxy::new(
+                c,
+                dbus_name.clone(),
+                "/org/mygestures/Daemon",
+                "org.mygestures.Daemon",
+            )
         } else {
             let new_conn = zbus::blocking::Connection::session()?;
-            zbus::blocking::Proxy::new(&new_conn, dbus_name.clone(), "/org/mygestures/Daemon", "org.mygestures.Daemon")
+            zbus::blocking::Proxy::new(
+                &new_conn,
+                dbus_name.clone(),
+                "/org/mygestures/Daemon",
+                "org.mygestures.Daemon",
+            )
         }?;
         let _: () = proxy.call("Stop", &())?;
         Ok(())
@@ -545,26 +559,37 @@ fn stop_daemon(conn: Option<&zbus::blocking::Connection>) {
     }
 }
 
-fn reload_daemon<W: IsA<gtk::Window>>(conn: Option<&zbus::blocking::Connection>, parent: Option<&W>) {
+fn reload_daemon<W: IsA<gtk::Window>>(
+    conn: Option<&zbus::blocking::Connection>,
+    parent: Option<&W>,
+) {
     let dbus_name = mygestures::config::get_dbus_name();
     let reload_via_dbus = || -> zbus::Result<()> {
         let proxy = if let Some(c) = conn {
-            zbus::blocking::Proxy::new(c, dbus_name.clone(), "/org/mygestures/Daemon", "org.mygestures.Daemon")
+            zbus::blocking::Proxy::new(
+                c,
+                dbus_name.clone(),
+                "/org/mygestures/Daemon",
+                "org.mygestures.Daemon",
+            )
         } else {
             let new_conn = zbus::blocking::Connection::session()?;
-            zbus::blocking::Proxy::new(&new_conn, dbus_name.clone(), "/org/mygestures/Daemon", "org.mygestures.Daemon")
+            zbus::blocking::Proxy::new(
+                &new_conn,
+                dbus_name.clone(),
+                "/org/mygestures/Daemon",
+                "org.mygestures.Daemon",
+            )
         }?;
         let _: () = proxy.call("Reload", &())?;
         Ok(())
     };
 
-    if let Err(e) = reload_via_dbus() {
-        if let zbus::Error::FDO(ref fdo_err) = e {
-            if let Some(p) = parent {
-                show_error_dialog(p, &fdo_err.to_string());
-            } else {
-                eprintln!("mygestures reload error: {}", fdo_err);
-            }
+    if let Err(zbus::Error::FDO(ref fdo_err)) = reload_via_dbus() {
+        if let Some(p) = parent {
+            show_error_dialog(p, &fdo_err.to_string());
+        } else {
+            eprintln!("mygestures reload error: {}", fdo_err);
         }
     }
 }
@@ -602,18 +627,33 @@ fn set_autostart_enabled(enabled: bool) {
 fn get_action_category_icon(action: &ActionType) -> (&'static str, &'static str) {
     match action {
         ActionType::Execute(_) => ("utilities-terminal-symbolic", "icon-bg-purple"),
-        ActionType::Keypress(_) => ("preferences-desktop-keyboard-shortcuts-symbolic", "icon-bg-orange"),
+        ActionType::Keypress(_) => (
+            "preferences-desktop-keyboard-shortcuts-symbolic",
+            "icon-bg-orange",
+        ),
         ActionType::Gnome(_) => ("preferences-system-symbolic", "icon-bg-blue"),
-        ActionType::WorkspaceLeft | ActionType::WorkspaceRight | ActionType::WorkspaceUp | ActionType::WorkspaceDown => {
-            ("go-next-symbolic", "icon-bg-blue")
+        ActionType::WorkspaceLeft
+        | ActionType::WorkspaceRight
+        | ActionType::WorkspaceUp
+        | ActionType::WorkspaceDown => ("go-next-symbolic", "icon-bg-blue"),
+        ActionType::VolumeUp | ActionType::VolumeDown | ActionType::VolumeMute => {
+            ("audio-volume-high-symbolic", "icon-bg-green")
         }
-        ActionType::VolumeUp | ActionType::VolumeDown | ActionType::VolumeMute => ("audio-volume-high-symbolic", "icon-bg-green"),
-        ActionType::MediaPlay | ActionType::MediaNext | ActionType::MediaPrev => ("media-playback-start-symbolic", "icon-bg-green"),
+        ActionType::MediaPlay | ActionType::MediaNext | ActionType::MediaPrev => {
+            ("media-playback-start-symbolic", "icon-bg-green")
+        }
         _ => ("system-run-symbolic", "icon-bg-blue"),
     }
 }
 
-fn draw_gesture_path(cr: &cairo::Context, points: &[Point2D], width: f64, height: f64, _draw_bg: bool, fit_to_canvas: bool) {
+fn draw_gesture_path(
+    cr: &cairo::Context,
+    points: &[Point2D],
+    width: f64,
+    height: f64,
+    _draw_bg: bool,
+    fit_to_canvas: bool,
+) {
     // Background is transparent to naturally display the theme-dependent container background (e.g. @view_bg_color)
 
     if points.len() < 2 {
@@ -627,10 +667,18 @@ fn draw_gesture_path(cr: &cairo::Context, points: &[Point2D], width: f64, height
     let mut max_y = points[0].y;
 
     for p in points {
-        if p.x < min_x { min_x = p.x; }
-        if p.x > max_x { max_x = p.x; }
-        if p.y < min_y { min_y = p.y; }
-        if p.y > max_y { max_y = p.y; }
+        if p.x < min_x {
+            min_x = p.x;
+        }
+        if p.x > max_x {
+            max_x = p.x;
+        }
+        if p.y < min_y {
+            min_y = p.y;
+        }
+        if p.y > max_y {
+            max_y = p.y;
+        }
     }
 
     let w = max_x - min_x;
@@ -638,7 +686,11 @@ fn draw_gesture_path(cr: &cairo::Context, points: &[Point2D], width: f64, height
     let max_dim = w.max(h);
     let scale = if fit_to_canvas {
         let size = width.min(height);
-        if max_dim > 1.0 { (size * 0.62) / max_dim } else { 1.0 }
+        if max_dim > 1.0 {
+            (size * 0.62) / max_dim
+        } else {
+            1.0
+        }
     } else {
         1.0
     };
@@ -673,17 +725,17 @@ fn draw_gesture_path(cr: &cairo::Context, points: &[Point2D], width: f64, height
     if points.len() >= 2 {
         let end = points.last().unwrap();
         let prev = &points[points.len() - 2];
-        
+
         let dy = end.y - prev.y;
         let dx = end.x - prev.x;
-        
+
         let len = (dx * dx + dy * dy).sqrt();
         if len > 0.001 {
             let angle = dy.atan2(dx);
-            
+
             // Arrowhead size relative to scale
             let arrow_length = 12.0 / scale;
-            
+
             // Calculate base corners perpendicular to the end of the line
             let half_width = 5.0 / scale;
             let perp_angle = angle + std::f64::consts::FRAC_PI_2;
@@ -691,11 +743,11 @@ fn draw_gesture_path(cr: &cairo::Context, points: &[Point2D], width: f64, height
             let y1 = end.y + half_width * perp_angle.sin();
             let x2 = end.x - half_width * perp_angle.cos();
             let y2 = end.y - half_width * perp_angle.sin();
-            
+
             // Calculate the tip pointing forward from the end of the line
             let tip_x = end.x + arrow_length * angle.cos();
             let tip_y = end.y + arrow_length * angle.sin();
-            
+
             cr.set_source_rgba(0.49, 0.27, 0.90, 1.0);
             cr.move_to(tip_x, tip_y);
             cr.line_to(x1, y1);
@@ -716,7 +768,7 @@ fn draw_gesture_path(cr: &cairo::Context, points: &[Point2D], width: f64, height
 fn create_gesture_row(gesture: &Gesture) -> gtk::ListBoxRow {
     let row = gtk::ListBoxRow::new();
     row.add_css_class("gesture-row");
-    
+
     let main_hbox = gtk::Box::new(gtk::Orientation::Horizontal, 16);
     main_hbox.set_margin_start(16);
     main_hbox.set_margin_end(16);
@@ -729,7 +781,7 @@ fn create_gesture_row(gesture: &Gesture) -> gtk::ListBoxRow {
     } else {
         ("system-run-symbolic", "icon-bg-blue")
     };
-    
+
     let icon_box = gtk::Box::new(gtk::Orientation::Horizontal, 0);
     icon_box.add_css_class("icon-holder");
     icon_box.add_css_class(bg_class);
@@ -758,7 +810,7 @@ fn create_gesture_row(gesture: &Gesture) -> gtk::ListBoxRow {
     action_label.set_halign(gtk::Align::Start);
     action_label.add_css_class("action-label");
     vbox.append(&action_label);
-    
+
     main_hbox.append(&vbox);
 
     // 3. Mini Cairo preview canvas
@@ -766,7 +818,7 @@ fn create_gesture_row(gesture: &Gesture) -> gtk::ListBoxRow {
     preview_frame.add_css_class("gesture-preview-frame");
     preview_frame.set_size_request(60, 60);
     preview_frame.set_valign(gtk::Align::Center);
-    
+
     let preview_canvas = gtk::DrawingArea::new();
     let pts_clone = gesture.points.clone();
     preview_canvas.set_draw_func(move |_, cr, width, height| {
@@ -781,17 +833,20 @@ fn create_gesture_row(gesture: &Gesture) -> gtk::ListBoxRow {
 fn get_visible_gestures(state: &AppState) -> Vec<Gesture> {
     let filter = state.search_entry.text().to_lowercase();
     let newly_added = &state.newly_added_gestures;
-    
-    let mut gestures: Vec<Gesture> = state.config.gestures.iter()
+
+    let mut gestures: Vec<Gesture> = state
+        .config
+        .gestures
+        .iter()
         .filter(|g| !g.is_deleted)
         .filter(|g| filter.is_empty() || g.name.to_lowercase().contains(&filter))
         .cloned()
         .collect();
-        
+
     gestures.sort_by(|a, b| {
         let a_new_idx = newly_added.iter().position(|name| name == &a.name);
         let b_new_idx = newly_added.iter().position(|name| name == &b.name);
-        
+
         match (a_new_idx, b_new_idx) {
             (Some(a_idx), Some(b_idx)) => b_idx.cmp(&a_idx), // most recently added first
             (Some(_), None) => std::cmp::Ordering::Less,
@@ -799,13 +854,13 @@ fn get_visible_gestures(state: &AppState) -> Vec<Gesture> {
             (None, None) => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
         }
     });
-    
+
     gestures
 }
 
 fn refresh_gesture_list(state_rc: &Rc<RefCell<AppState>>, select_name: Option<&str>) {
     let state = state_rc.borrow();
-    
+
     // Clear list
     while let Some(child) = state.main_list.first_child() {
         state.main_list.remove(&child);
@@ -816,7 +871,7 @@ fn refresh_gesture_list(state_rc: &Rc<RefCell<AppState>>, select_name: Option<&s
     for gesture in &visible {
         let row = create_gesture_row(gesture);
         state.main_list.append(&row);
-        
+
         if let Some(name) = select_name {
             if gesture.name == name {
                 state.main_list.select_row(Some(&row));
@@ -853,10 +908,10 @@ fn get_default_gesture_name(opt: &EditorActionOption, detail: &str) -> String {
 }
 
 fn open_shortcut_recorder(
-    parent: &gtk::Window, 
-    gesture_name: &str, 
-    entry: &gtk::Entry, 
-    udn: Rc<dyn Fn() + 'static>
+    parent: &gtk::Window,
+    gesture_name: &str,
+    entry: &gtk::Entry,
+    udn: Rc<dyn Fn() + 'static>,
 ) {
     let dialog = gtk::Window::new();
     dialog.set_transient_for(Some(parent));
@@ -905,7 +960,10 @@ fn open_shortcut_recorder(
 
     let prompt_label = gtk::Label::new(None);
     let escaped_name = glib::markup_escape_text(gesture_name);
-    prompt_label.set_markup(&format!("Enter new shortcut to change <b>{}</b>", escaped_name));
+    prompt_label.set_markup(&format!(
+        "Enter new shortcut to change <b>{}</b>",
+        escaped_name
+    ));
     prompt_label.set_wrap(true);
     prompt_label.set_justify(gtk::Justification::Center);
     vbox.append(&prompt_label);
@@ -927,7 +985,9 @@ fn open_shortcut_recorder(
     shortcut_display_box.set_visible(false);
     vbox.append(&shortcut_display_box);
 
-    let hint_label = gtk::Label::new(Some("Press Esc to cancel or Backspace to reset the shortcut"));
+    let hint_label = gtk::Label::new(Some(
+        "Press Esc to cancel or Backspace to reset the shortcut",
+    ));
     hint_label.add_css_class("action-label");
     hint_label.set_justify(gtk::Justification::Center);
     vbox.append(&hint_label);
@@ -998,14 +1058,19 @@ fn open_shortcut_recorder(
             display_mods.push("Super");
         }
 
-        let is_modifier = match keyval {
-            gdk::Key::Control_L | gdk::Key::Control_R |
-            gdk::Key::Alt_L | gdk::Key::Alt_R |
-            gdk::Key::Shift_L | gdk::Key::Shift_R |
-            gdk::Key::Super_L | gdk::Key::Super_R |
-            gdk::Key::Meta_L | gdk::Key::Meta_R => true,
-            _ => false,
-        };
+        let is_modifier = matches!(
+            keyval,
+            gdk::Key::Control_L
+                | gdk::Key::Control_R
+                | gdk::Key::Alt_L
+                | gdk::Key::Alt_R
+                | gdk::Key::Shift_L
+                | gdk::Key::Shift_R
+                | gdk::Key::Super_L
+                | gdk::Key::Super_R
+                | gdk::Key::Meta_L
+                | gdk::Key::Meta_R
+        );
 
         if is_modifier {
             return glib::Propagation::Stop;
@@ -1073,12 +1138,20 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
     let dialog = gtk::Window::new();
     dialog.set_transient_for(Some(&state.window));
     dialog.set_modal(true);
-    dialog.set_title(Some(if target_gesture.is_some() { "Edit Gesture" } else { "Add Gesture" }));
+    dialog.set_title(Some(if target_gesture.is_some() {
+        "Edit Gesture"
+    } else {
+        "Add Gesture"
+    }));
     dialog.set_default_size(480, 620);
 
     let dialog_header = gtk::HeaderBar::new();
     dialog_header.set_show_title_buttons(false);
-    let dialog_title = gtk::Label::new(Some(if target_gesture.is_some() { "Edit Gesture" } else { "Add Gesture" }));
+    let dialog_title = gtk::Label::new(Some(if target_gesture.is_some() {
+        "Edit Gesture"
+    } else {
+        "Add Gesture"
+    }));
     dialog_title.add_css_class("title");
     dialog_header.set_title_widget(Some(&dialog_title));
     dialog.set_titlebar(Some(&dialog_header));
@@ -1117,11 +1190,7 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
         if *prog_clone.borrow() {
             return;
         }
-        if entry.text().trim().is_empty() {
-            *cust_clone.borrow_mut() = false;
-        } else {
-            *cust_clone.borrow_mut() = true;
-        }
+        *cust_clone.borrow_mut() = !entry.text().trim().is_empty();
     });
 
     // --- GESTURE PATH SECTION ---
@@ -1137,7 +1206,10 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
 
     let canvas = gtk::DrawingArea::new();
     let recorded_points: Rc<RefCell<Vec<Point2D>>> = Rc::new(RefCell::new(
-        target_gesture.as_ref().map(|g| g.points.clone()).unwrap_or_default()
+        target_gesture
+            .as_ref()
+            .map(|g| g.points.clone())
+            .unwrap_or_default(),
     ));
     let is_recording = Rc::new(RefCell::new(false));
 
@@ -1176,8 +1248,14 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
         *rec_drag.borrow_mut() = true;
         let mut pts = pts_drag.borrow_mut();
         pts.clear();
-        pts.push(Point2D { x: start_x, y: start_y });
-        println!("GUI: Gesture drawing started at ({:.1}, {:.1})", start_x, start_y);
+        pts.push(Point2D {
+            x: start_x,
+            y: start_y,
+        });
+        println!(
+            "GUI: Gesture drawing started at ({:.1}, {:.1})",
+            start_x, start_y
+        );
         canvas_clone.queue_draw();
         conflict_box_begin.set_visible(false);
     });
@@ -1193,7 +1271,7 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
             let cx = start_x + offset_x;
             let cy = start_y + offset_y;
             let mut pts = pts_drag2.borrow_mut();
-            
+
             // Filter jitter
             let add = match pts.last() {
                 Some(lp) => {
@@ -1225,7 +1303,10 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
         let pts = pts_drag_end.borrow();
         if pts.len() >= 2 {
             let state = state_clone_drag.borrow();
-            let templates: Vec<(String, Vec<Point2D>)> = state.config.gestures.iter()
+            let templates: Vec<(String, Vec<Point2D>)> = state
+                .config
+                .gestures
+                .iter()
                 .filter(|g| !g.is_deleted)
                 .filter(|g| {
                     if let Some(ref name) = edited_gesture_name {
@@ -1236,7 +1317,7 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
                 })
                 .map(|g| (g.name.clone(), g.points.clone()))
                 .collect();
-            
+
             if let Some(matched_name) = match_gesture(&pts[..], &templates) {
                 conflict_label_end.set_text(&format!(
                     "Warning: This path is very similar to the existing gesture '{}'.",
@@ -1341,27 +1422,27 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
 
     let entry_container = gtk::Box::new(gtk::Orientation::Horizontal, 6);
     entry_container.set_halign(gtk::Align::End);
- 
+
     let action_details_entry = gtk::Entry::new();
     action_details_entry.set_size_request(160, -1);
     entry_container.append(&action_details_entry);
- 
+
     // Add shortcut display box for keycaps representation
     let shortcut_display_box = gtk::Box::new(gtk::Orientation::Horizontal, 6);
     shortcut_display_box.set_halign(gtk::Align::End);
     shortcut_display_box.set_valign(gtk::Align::Center);
     shortcut_display_box.set_visible(false);
     entry_container.append(&shortcut_display_box);
- 
+
     let record_btn = gtk::Button::from_icon_name("media-record-symbolic");
     record_btn.set_tooltip_text(Some("Record Keybinding"));
     entry_container.append(&record_btn);
- 
+
     action_details_row.append(&entry_container);
     settings_list.append(&action_details_row);
- 
+
     let current_options: Rc<RefCell<Vec<EditorActionOption>>> = Rc::new(RefCell::new(Vec::new()));
- 
+
     // Helper to dynamically update the gesture name if not customized
     let update_default_name = Rc::new({
         let name_entry = name_entry.clone();
@@ -1370,7 +1451,7 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
         let current_options = Rc::clone(&current_options);
         let is_name_customized = Rc::clone(&is_name_customized);
         let is_updating_programmatically = Rc::clone(&is_updating_programmatically);
- 
+
         move || {
             if *is_name_customized.borrow() {
                 return;
@@ -1385,30 +1466,34 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
                 let opt = &opts[act_idx];
                 let detail = action_details_entry.text().to_string();
                 let default_name = get_default_gesture_name(opt, &detail);
-                
+
                 *is_updating_programmatically.borrow_mut() = true;
                 name_entry.set_text(&default_name);
                 *is_updating_programmatically.borrow_mut() = false;
             }
         }
     });
- 
+
     // Setup record button to open the "Set Shortcut" modal dialog
     let entry_click = action_details_entry.clone();
     let dialog_parent = dialog.clone();
     let name_entry_click = name_entry.clone();
     let udn_click = Rc::clone(&update_default_name);
- 
+
     record_btn.connect_clicked(move |_| {
         let gesture_name = name_entry_click.text().to_string();
         open_shortcut_recorder(
-            &dialog_parent, 
-            if gesture_name.trim().is_empty() { "Gesture" } else { &gesture_name }, 
-            &entry_click, 
-            Rc::clone(&udn_click) as Rc<dyn Fn()>
+            &dialog_parent,
+            if gesture_name.trim().is_empty() {
+                "Gesture"
+            } else {
+                &gesture_name
+            },
+            &entry_click,
+            Rc::clone(&udn_click) as Rc<dyn Fn()>,
         );
     });
- 
+
     // Helper to update shortcut display box with keycaps
     let update_shortcut_display = {
         let entry = action_details_entry.clone();
@@ -1418,7 +1503,7 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
             while let Some(child) = display_box.first_child() {
                 display_box.remove(&child);
             }
- 
+
             let text = entry.text().to_string();
             if text.trim().is_empty() {
                 let label = gtk::Label::new(Some("None"));
@@ -1439,32 +1524,33 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
             }
         })
     };
- 
+
     // Build options list
     let mut all_options = get_static_action_options();
     all_options.extend(fetch_gnome_action_options());
- 
+
     // Find initial matching option
     let mut selected_cat = 0;
     let mut selected_act = 0;
- 
+
     if let Some(ref g) = target_gesture {
         if !g.actions.is_empty() {
             let a = &g.actions[0];
             if let Some(found_opt) = all_options.iter().find(|opt| action_matches(a, opt)) {
                 selected_cat = found_opt.category;
- 
+
                 // Get the filtered options for this category
-                let filtered: Vec<EditorActionOption> = all_options.iter()
+                let filtered: Vec<EditorActionOption> = all_options
+                    .iter()
                     .filter(|opt| opt.category == selected_cat)
                     .cloned()
                     .collect();
- 
+
                 // Find index of option within the filtered list
                 if let Some(act_idx) = filtered.iter().position(|opt| action_matches(a, opt)) {
                     selected_act = act_idx;
                 }
- 
+
                 // If the action contains input text details, populate it
                 match a {
                     ActionType::Keypress(combo) => {
@@ -1484,23 +1570,27 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
             }
         }
     }
- 
+
     // Filter options for initial category and set model/selections
-    let initial_filtered: Vec<EditorActionOption> = all_options.iter()
+    let initial_filtered: Vec<EditorActionOption> = all_options
+        .iter()
         .filter(|opt| opt.category == selected_cat)
         .cloned()
         .collect();
- 
-    let action_names: Vec<String> = initial_filtered.iter().map(|opt| opt.name.clone()).collect();
+
+    let action_names: Vec<String> = initial_filtered
+        .iter()
+        .map(|opt| opt.name.clone())
+        .collect();
     let action_refs: Vec<&str> = action_names.iter().map(|s| s.as_str()).collect();
     let action_model = gtk::StringList::new(&action_refs);
     action_dropdown.set_model(Some(&action_model));
- 
+
     *current_options.borrow_mut() = initial_filtered.clone();
- 
+
     category_dropdown.set_selected(selected_cat as u32);
     action_dropdown.set_selected(selected_act as u32);
- 
+
     // Initialize details entry visibility, label, placeholder, and record button
     if selected_act < initial_filtered.len() {
         let opt = &initial_filtered[selected_act];
@@ -1511,12 +1601,12 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
             _ => false,
         };
         action_details_row.set_visible(show_entry);
-        
+
         let is_keypress = matches!(&opt.action_type, ActionType::Keypress(_));
         action_details_entry.set_visible(!is_keypress);
         shortcut_display_box.set_visible(is_keypress);
         record_btn.set_visible(is_keypress);
- 
+
         match &opt.action_type {
             ActionType::Keypress(_) => {
                 action_details_label.set_text("Keys to Send");
@@ -1527,27 +1617,28 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
             }
             ActionType::Click(_) => {
                 action_details_label.set_text("Mouse Button");
-                action_details_entry.set_placeholder_text(Some("e.g. 1 (Left), 2 (Middle), 3 (Right)"));
+                action_details_entry
+                    .set_placeholder_text(Some("e.g. 1 (Left), 2 (Middle), 3 (Right)"));
             }
             _ => {}
         }
     }
- 
+
     let usd_init = Rc::clone(&update_shortcut_display);
     usd_init(); // Set initial keycaps if keys exist
- 
+
     let udn_clone = Rc::clone(&update_default_name);
     if target_gesture.is_none() {
         udn_clone();
     }
- 
+
     let udn_clone4 = Rc::clone(&update_default_name);
     let usd_clone_change = Rc::clone(&update_shortcut_display);
     action_details_entry.connect_changed(move |_| {
         udn_clone4();
         usd_clone_change();
     });
- 
+
     // Connect category changed signal
     let all_options_clone = all_options.clone();
     let current_opts_clone = Rc::clone(&current_options);
@@ -1558,26 +1649,27 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
     let record_btn_clone_cat = record_btn.clone();
     let udn_clone3 = Rc::clone(&update_default_name);
     let sdb_clone_cat = shortcut_display_box.clone();
- 
+
     category_dropdown.connect_selected_notify(move |cat_dd| {
         let cat_idx = cat_dd.selected();
         if cat_idx == gtk::INVALID_LIST_POSITION {
             return;
         }
         let cat_idx = cat_idx as usize;
-        let filtered: Vec<EditorActionOption> = all_options_clone.iter()
+        let filtered: Vec<EditorActionOption> = all_options_clone
+            .iter()
             .filter(|opt| opt.category == cat_idx)
             .cloned()
             .collect();
- 
+
         let action_names: Vec<String> = filtered.iter().map(|opt| opt.name.clone()).collect();
         let action_refs: Vec<&str> = action_names.iter().map(|s| s.as_str()).collect();
         let action_model = gtk::StringList::new(&action_refs);
         action_dropdown_clone.set_model(Some(&action_model));
- 
+
         *current_opts_clone.borrow_mut() = filtered.clone();
         action_dropdown_clone.set_selected(0);
- 
+
         // Manually update details entry visibility/placeholder/label/record_btn for index 0
         if !filtered.is_empty() {
             let opt = &filtered[0];
@@ -1588,12 +1680,12 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
                 _ => false,
             };
             row_clone.set_visible(show_entry);
-            
+
             let is_keypress = matches!(&opt.action_type, ActionType::Keypress(_));
             entry_clone.set_visible(!is_keypress);
             sdb_clone_cat.set_visible(is_keypress);
             record_btn_clone_cat.set_visible(is_keypress);
- 
+
             match &opt.action_type {
                 ActionType::Keypress(_) => {
                     label_clone.set_text("Keys to Send");
@@ -1609,10 +1701,10 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
                 _ => {}
             }
         }
- 
+
         udn_clone3();
     });
- 
+
     // Connect action changed signal
     let current_opts_clone2 = Rc::clone(&current_options);
     let entry_clone2 = action_details_entry.clone();
@@ -1621,14 +1713,14 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
     let record_btn_clone_act = record_btn.clone();
     let udn_clone2 = Rc::clone(&update_default_name);
     let sdb_clone_act = shortcut_display_box.clone();
- 
+
     action_dropdown.connect_selected_notify(move |act_dd| {
         let act_idx = act_dd.selected();
         if act_idx == gtk::INVALID_LIST_POSITION {
             return;
         }
         let act_idx = act_idx as usize;
- 
+
         let opts = current_opts_clone2.borrow();
         if act_idx < opts.len() {
             let opt = &opts[act_idx];
@@ -1639,12 +1731,12 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
                 _ => false,
             };
             row_clone2.set_visible(show_entry);
- 
+
             let is_keypress = matches!(&opt.action_type, ActionType::Keypress(_));
             entry_clone2.set_visible(!is_keypress);
             sdb_clone_act.set_visible(is_keypress);
             record_btn_clone_act.set_visible(is_keypress);
- 
+
             match &opt.action_type {
                 ActionType::Keypress(_) => {
                     label_clone2.set_text("Keys to Send");
@@ -1660,7 +1752,7 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
                 _ => {}
             }
         }
- 
+
         udn_clone2();
     });
 
@@ -1674,12 +1766,12 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
 
     let save_btn = gtk::Button::with_label("Save");
     save_btn.add_css_class("suggested-action");
-    
+
     let state_clone = Rc::clone(state_rc);
     let is_edit = target_gesture.is_some();
     let target_id = target_gesture.as_ref().map(|g| g.id.clone());
     let dialog_clone2 = dialog.clone();
-    
+
     let current_opts_save = Rc::clone(&current_options);
     save_btn.connect_clicked(move |_| {
         let name = name_entry.text().to_string();
@@ -1695,7 +1787,8 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
         }
 
         // Convert recorded points back to string coords representation
-        let raw_movement = pts.iter()
+        let raw_movement = pts
+            .iter()
             .map(|p| format!("{},{}", p.x as i32, p.y as i32))
             .collect::<Vec<_>>()
             .join(" ");
@@ -1732,11 +1825,19 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
         let mut state = state_clone.borrow_mut();
         if is_edit {
             let lookup_id = target_id.as_ref().unwrap();
-            if let Some(pos) = state.config.gestures.iter().position(|g| g.id == *lookup_id) {
+            if let Some(pos) = state
+                .config
+                .gestures
+                .iter()
+                .position(|g| g.id == *lookup_id)
+            {
                 let lookup_name = state.config.gestures[pos].name.clone();
                 if name != lookup_name {
                     if state.config.gestures.iter().any(|g| g.name == name) {
-                        println!("Gesture save failed: A gesture with the name '{}' already exists.", name);
+                        println!(
+                            "Gesture save failed: A gesture with the name '{}' already exists.",
+                            name
+                        );
                         return;
                     }
                     state.config.gestures[pos].name = name.clone();
@@ -1751,12 +1852,18 @@ fn open_gesture_editor(state_rc: &Rc<RefCell<AppState>>, target_gesture: Option<
                     println!("Gesture modified successfully: {}", name);
                 }
             } else {
-                println!("Gesture modification failed: Could not find gesture with ID '{}'", lookup_id);
+                println!(
+                    "Gesture modification failed: Could not find gesture with ID '{}'",
+                    lookup_id
+                );
             }
         } else {
             // Check if name conflict
             if state.config.gestures.iter().any(|g| g.name == name) {
-                println!("Gesture save failed: A gesture with the name '{}' already exists.", name);
+                println!(
+                    "Gesture save failed: A gesture with the name '{}' already exists.",
+                    name
+                );
                 return;
             }
             println!("Gesture added successfully: {}", name);
@@ -1864,7 +1971,9 @@ fn build_ui(app: &gtk::Application) {
     title_label.set_halign(gtk::Align::Start);
     text_vbox.append(&title_label);
 
-    let subtitle_label = gtk::Label::new(Some("Run background daemon service to monitor mouse gestures"));
+    let subtitle_label = gtk::Label::new(Some(
+        "Run background daemon service to monitor mouse gestures",
+    ));
     subtitle_label.add_css_class("action-label");
     subtitle_label.set_halign(gtk::Align::Start);
     text_vbox.append(&subtitle_label);
@@ -1924,9 +2033,12 @@ fn build_ui(app: &gtk::Application) {
 
     // Connect search entry
     let state_clone = Rc::clone(&state);
-    state.borrow().search_entry.connect_search_changed(move |_| {
-        refresh_gesture_list(&state_clone, None);
-    });
+    state
+        .borrow()
+        .search_entry
+        .connect_search_changed(move |_| {
+            refresh_gesture_list(&state_clone, None);
+        });
 
     // Connect Add button
     let state_clone2 = Rc::clone(&state);
@@ -1936,18 +2048,21 @@ fn build_ui(app: &gtk::Application) {
 
     // Connect row activation for editing
     let state_clone3 = Rc::clone(&state);
-    state.borrow().main_list.connect_row_activated(move |_, row| {
-        let idx = row.index();
-        let state_borrow = state_clone3.borrow();
-        
-        let visible_gestures = get_visible_gestures(&state_borrow);
+    state
+        .borrow()
+        .main_list
+        .connect_row_activated(move |_, row| {
+            let idx = row.index();
+            let state_borrow = state_clone3.borrow();
 
-        if idx >= 0 && (idx as usize) < visible_gestures.len() {
-            let gesture = visible_gestures[idx as usize].clone();
-            drop(state_borrow);
-            open_gesture_editor(&state_clone3, Some(gesture));
-        }
-    });
+            let visible_gestures = get_visible_gestures(&state_borrow);
+
+            if idx >= 0 && (idx as usize) < visible_gestures.len() {
+                let gesture = visible_gestures[idx as usize].clone();
+                drop(state_borrow);
+                open_gesture_editor(&state_clone3, Some(gesture));
+            }
+        });
 
     // Connect about button
     let window_clone = state.borrow().window.clone();
@@ -1956,36 +2071,41 @@ fn build_ui(app: &gtk::Application) {
         dialog.set_transient_for(Some(&window_clone));
         dialog.set_program_name(Some("Gestos"));
         dialog.set_version(Some("4.1.9"));
-        dialog.set_comments(Some("A modern mouse gestures editor for Wayland desktop environments."));
+        dialog.set_comments(Some(
+            "A modern mouse gestures editor for Wayland desktop environments.",
+        ));
         dialog.set_authors(&["Lucas Augusto Deters <lucasdeters@gmail.com>"]);
         dialog.present();
     });
 
     // Connect daemon switch state controller
     let state_clone4 = Rc::clone(&state);
-    let handler_id = state.borrow().daemon_switch.connect_state_set(move |_, state| {
-        if state {
-            if let Err(err) = start_daemon(state_clone4.borrow().dbus_conn.as_ref()) {
-                show_error_dialog(&state_clone4.borrow().window, &err);
+    let handler_id = state
+        .borrow()
+        .daemon_switch
+        .connect_state_set(move |_, state| {
+            if state {
+                if let Err(err) = start_daemon(state_clone4.borrow().dbus_conn.as_ref()) {
+                    show_error_dialog(&state_clone4.borrow().window, &err);
+                }
+                set_autostart_enabled(true);
+            } else {
+                stop_daemon(state_clone4.borrow().dbus_conn.as_ref());
+                set_autostart_enabled(false);
             }
-            set_autostart_enabled(true);
-        } else {
-            stop_daemon(state_clone4.borrow().dbus_conn.as_ref());
-            set_autostart_enabled(false);
-        }
-        
-        let state_borrow = state_clone4.borrow();
-        let running = is_daemon_running(state_borrow.dbus_conn.as_ref());
-        if !running {
-            // Toggle the switch back off immediately if daemon startup failed
-            if let Some(ref hid) = state_borrow.switch_handler_id {
-                state_borrow.daemon_switch.block_signal(hid);
-                state_borrow.daemon_switch.set_active(false);
-                state_borrow.daemon_switch.unblock_signal(hid);
+
+            let state_borrow = state_clone4.borrow();
+            let running = is_daemon_running(state_borrow.dbus_conn.as_ref());
+            if !running {
+                // Toggle the switch back off immediately if daemon startup failed
+                if let Some(ref hid) = state_borrow.switch_handler_id {
+                    state_borrow.daemon_switch.block_signal(hid);
+                    state_borrow.daemon_switch.set_active(false);
+                    state_borrow.daemon_switch.unblock_signal(hid);
+                }
             }
-        }
-        glib::Propagation::Proceed
-    });
+            glib::Propagation::Proceed
+        });
     state.borrow_mut().switch_handler_id = Some(handler_id);
 
     // Setup periodic status check timer (every 1 second)

--- a/src/bin/mygestures.rs
+++ b/src/bin/mygestures.rs
@@ -1,9 +1,9 @@
+use mygestures::config::{ActionType, Configuration};
+use mygestures::ipc::DaemonIpc;
+use mygestures::wayland::WaylandContext;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use mygestures::config::{Configuration, ActionType};
-use mygestures::wayland::WaylandContext;
-use mygestures::ipc::DaemonIpc;
 use zbus::interface;
 
 static RELOAD_REQUESTED: AtomicBool = AtomicBool::new(false);
@@ -43,20 +43,22 @@ impl DaemonDbus {
         if IS_MANAGER.load(Ordering::Relaxed) {
             let path = mygestures::config::get_default_config_path();
             if mygestures::config::Configuration::load_from_file(&path).is_none() {
-                return Err(zbus::fdo::Error::Failed("Invalid configuration file format".to_string()));
+                return Err(zbus::fdo::Error::Failed(
+                    "Invalid configuration file format".to_string(),
+                ));
             }
             RELOAD_MANAGER.store(true, Ordering::Relaxed);
             kill_children();
         } else {
             let path = mygestures::config::get_default_config_path();
             if mygestures::config::Configuration::load_from_file(&path).is_none() {
-                return Err(zbus::fdo::Error::Failed("Invalid configuration file format".to_string()));
+                return Err(zbus::fdo::Error::Failed(
+                    "Invalid configuration file format".to_string(),
+                ));
             }
             RELOAD_REQUESTED.store(true, Ordering::Relaxed);
-            let _ = nix::sys::signal::kill(
-                nix::unistd::Pid::this(),
-                nix::sys::signal::Signal::SIGUSR1,
-            );
+            let _ =
+                nix::sys::signal::kill(nix::unistd::Pid::this(), nix::sys::signal::Signal::SIGUSR1);
         }
         Ok(())
     }
@@ -94,12 +96,16 @@ fn check_permissions(device: &str) -> bool {
     if let Ok(file) = std::fs::OpenOptions::new().write(true).open("/dev/uinput") {
         uinput_ok = true;
         drop(file);
-    } else if let Ok(file) = std::fs::OpenOptions::new().write(true).open("/dev/misc/uinput") {
+    } else if let Ok(file) = std::fs::OpenOptions::new()
+        .write(true)
+        .open("/dev/misc/uinput")
+    {
         uinput_ok = true;
         drop(file);
     }
 
-    let uinput_exists = std::path::Path::new("/dev/uinput").exists() || std::path::Path::new("/dev/misc/uinput").exists();
+    let uinput_exists = std::path::Path::new("/dev/uinput").exists()
+        || std::path::Path::new("/dev/misc/uinput").exists();
     let dev_ok = std::fs::OpenOptions::new().read(true).open(device).is_ok();
 
     if !uinput_ok || !dev_ok {
@@ -121,20 +127,24 @@ fn check_permissions(device: &str) -> bool {
             eprintln!("1. Load the uinput kernel module:");
             eprintln!("   sudo modprobe uinput");
             eprintln!("   (To load it automatically on boot, add 'uinput' to /etc/modules)\n");
-            eprintln!("=========================================================================\n");
+            eprintln!(
+                "=========================================================================\n"
+            );
             return false;
         }
 
         eprintln!("\nTo resolve permissions, choose one of the following setups:\n");
         eprintln!("OPTION A: SECURE SETUP (Recommended - Only mygestures has access)");
-        eprintln!("  1. Install the mygestures udev rules (restricts access to the 'input' group):");
+        eprintln!(
+            "  1. Install the mygestures udev rules (restricts access to the 'input' group):"
+        );
         eprintln!("     sudo cp 99-mygestures.rules /etc/udev/rules.d/");
         eprintln!("     sudo udevadm control --reload-rules && sudo udevadm trigger");
         eprintln!("  2. Configure the mygestures binary to run as Set-Group-ID (SGID) to 'input':");
         eprintln!("     sudo chown root:input /usr/local/bin/mygestures");
         eprintln!("     sudo chmod 2755 /usr/local/bin/mygestures");
         eprintln!("     (Note: This allows only this binary to capture inputs/inject actions)");
-        
+
         eprintln!("\nOPTION B: STANDARD SETUP (Allows all user applications to capture inputs)");
         eprintln!("  1. Add your user to the 'input' group:");
         eprintln!("     sudo usermod -aG input $USER");
@@ -157,7 +167,7 @@ fn run_grabber(
     ipc: mygestures::ipc::DaemonIpc,
 ) -> Result<(), std::io::Error> {
     use evdev::{Device, EventType, KeyCode};
-    use mygestures::protractor::{Point2D, match_gesture};
+    use mygestures::protractor::{match_gesture, Point2D};
     use mygestures::uinput::UinputDevice;
 
     println!("Attempting to open device: {}", device_path);
@@ -165,7 +175,9 @@ fn run_grabber(
 
     // Adjust sensitivity threshold if relative device vs absolute device
     let mut threshold = sensitivity as f64;
-    let abs_x = dev.get_absinfo().ok()
+    let abs_x = dev
+        .get_absinfo()
+        .ok()
         .and_then(|mut iter| iter.find(|(code, _)| *code == evdev::AbsoluteAxisCode::ABS_X))
         .map(|(_, info)| info);
     if let Some(abs_info) = abs_x {
@@ -215,13 +227,19 @@ fn run_grabber(
     let egid = nix::unistd::getegid();
     if egid != rgid {
         if nix::unistd::setegid(rgid).is_ok() {
-            println!("mygestures: Successfully dropped elevated GID from {} to {}", egid, rgid);
+            println!(
+                "mygestures: Successfully dropped elevated GID from {} to {}",
+                egid, rgid
+            );
         } else {
             eprintln!("mygestures: Warning: Failed to drop elevated GID.");
         }
     }
 
-    println!("Listening for events from device using libevdev (button {})", trigger_button);
+    println!(
+        "Listening for events from device using libevdev (button {})",
+        trigger_button
+    );
 
     let mut is_drawing = false;
     let mut captured_points = Vec::new();
@@ -230,7 +248,9 @@ fn run_grabber(
     let mut moved = false;
 
     // Convert templates for matching
-    let mut templates: Vec<(String, Vec<Point2D>)> = config.gestures.iter()
+    let mut templates: Vec<(String, Vec<Point2D>)> = config
+        .gestures
+        .iter()
         .filter(|g| !g.is_deleted)
         .map(|g| (g.name.clone(), g.points.clone()))
         .collect();
@@ -239,15 +259,22 @@ fn run_grabber(
     loop {
         if RELOAD_REQUESTED.swap(false, Ordering::Relaxed) {
             println!("mygestures: Reloading configuration dynamically...");
-            if let Some(new_config) = mygestures::config::Configuration::load_from_file(&config.user_config_path) {
+            if let Some(new_config) =
+                mygestures::config::Configuration::load_from_file(&config.user_config_path)
+            {
                 config = new_config;
-                templates = config.gestures.iter()
+                templates = config
+                    .gestures
+                    .iter()
                     .filter(|g| !g.is_deleted)
                     .map(|g| (g.name.clone(), g.points.clone()))
                     .collect();
                 println!("mygestures: Configuration reloaded successfully.");
             } else {
-                eprintln!("mygestures: Failed to reload configuration from {}", config.user_config_path.display());
+                eprintln!(
+                    "mygestures: Failed to reload configuration from {}",
+                    config.user_config_path.display()
+                );
             }
         }
 
@@ -274,18 +301,30 @@ fn run_grabber(
                     // Start gesture movement
                     is_drawing = true;
                     captured_points.clear();
-                    captured_points.push(Point2D { x: virtual_x, y: virtual_y });
-                    println!("Gesture drawing started at ({:.1}, {:.1})", virtual_x, virtual_y);
+                    captured_points.push(Point2D {
+                        x: virtual_x,
+                        y: virtual_y,
+                    });
+                    println!(
+                        "Gesture drawing started at ({:.1}, {:.1})",
+                        virtual_x, virtual_y
+                    );
                 } else if ev_value == 0 {
                     // End gesture movement
                     is_drawing = false;
-                    
+
                     // Final coordinate
                     if moved {
-                        captured_points.push(Point2D { x: virtual_x, y: virtual_y });
+                        captured_points.push(Point2D {
+                            x: virtual_x,
+                            y: virtual_y,
+                        });
                     }
 
-                    println!("Gesture drawing finished. Path points: {}", captured_points.len());
+                    println!(
+                        "Gesture drawing finished. Path points: {}",
+                        captured_points.len()
+                    );
 
                     // Calculate path length
                     let len = mygestures::protractor::path_length(&captured_points);
@@ -300,7 +339,9 @@ fn run_grabber(
                     } else {
                         // Match gesture
                         if let Some(matched_name) = match_gesture(&captured_points, &templates) {
-                            if let Some(gesture) = config.gestures.iter().find(|g| g.name == matched_name) {
+                            if let Some(gesture) =
+                                config.gestures.iter().find(|g| g.name == matched_name)
+                            {
                                 println!("Matched gesture: {}", gesture.name);
                                 for action in &gesture.actions {
                                     if let ActionType::Click(btn) = action {
@@ -333,34 +374,43 @@ fn run_grabber(
 
                 // Update coordinate tracking
                 if ev_type == EventType::RELATIVE {
-                    if ev_code == 0 { // REL_X
+                    if ev_code == 0 {
+                        // REL_X
                         virtual_x += ev_value as f64;
                         moved = true;
-                    } else if ev_code == 1 { // REL_Y
+                    } else if ev_code == 1 {
+                        // REL_Y
                         virtual_y += ev_value as f64;
                         moved = true;
                     }
                 } else if ev_type == EventType::ABSOLUTE {
-                    if ev_code == 0 { // ABS_X
+                    if ev_code == 0 {
+                        // ABS_X
                         virtual_x = ev_value as f64;
                         moved = true;
-                    } else if ev_code == 1 { // ABS_Y
+                    } else if ev_code == 1 {
+                        // ABS_Y
                         virtual_y = ev_value as f64;
                         moved = true;
                     }
-                } else if ev_type == EventType::SYNCHRONIZATION && ev_code == 0 { // SYN_REPORT
+                } else if ev_type == EventType::SYNCHRONIZATION && ev_code == 0 {
+                    // SYN_REPORT
                     if moved && is_drawing {
                         let last = captured_points.last();
                         let add_point = match last {
                             Some(lp) => {
                                 let dx = virtual_x - lp.x;
                                 let dy = virtual_y - lp.y;
-                                dx * dx + dy * dy >= threshold * threshold / 100.0 // check sensitivity threshold
+                                dx * dx + dy * dy >= threshold * threshold / 100.0
+                                // check sensitivity threshold
                             }
                             None => true,
                         };
                         if add_point {
-                            captured_points.push(Point2D { x: virtual_x, y: virtual_y });
+                            captured_points.push(Point2D {
+                                x: virtual_x,
+                                y: virtual_y,
+                            });
                         }
                     }
                     moved = false;
@@ -416,9 +466,15 @@ fn main() {
         } else if arg.starts_with("--device=") {
             devices.push(arg.trim_start_matches("--device=").to_string());
         } else if arg.starts_with("--button=") {
-            button = arg.trim_start_matches("--button=").parse::<i32>().unwrap_or(3);
+            button = arg
+                .trim_start_matches("--button=")
+                .parse::<i32>()
+                .unwrap_or(3);
         } else if arg.starts_with("--sensitivity=") {
-            sensitivity = arg.trim_start_matches("--sensitivity=").parse::<i32>().unwrap_or(30);
+            sensitivity = arg
+                .trim_start_matches("--sensitivity=")
+                .parse::<i32>()
+                .unwrap_or(30);
         } else if !arg.starts_with('-') {
             custom_config = Some(arg);
         }
@@ -428,7 +484,10 @@ fn main() {
         println!("Usage: mygestures [OPTIONS] [CONFIG_FILE]");
         println!();
         println!("CONFIG_FILE:");
-        println!("  Default: {}", mygestures::config::get_default_config_path().display());
+        println!(
+            "  Default: {}",
+            mygestures::config::get_default_config_path().display()
+        );
         println!();
         println!("OPTIONS:");
         println!("  -d, --device <DEVICENAME>  : Device to grab (can specify multiple times)");
@@ -476,7 +535,7 @@ fn main() {
     // If multiple devices are specified, run process manager
     if devices.len() > 1 {
         IS_MANAGER.store(true, Ordering::Relaxed);
-        
+
         loop {
             let exe = std::env::current_exe().unwrap();
             let mut children = Vec::new();
@@ -514,7 +573,9 @@ fn main() {
             }
 
             if RELOAD_MANAGER.swap(false, Ordering::Relaxed) {
-                println!("mygestures parent: Config reload triggered. Restarting child processes...");
+                println!(
+                    "mygestures parent: Config reload triggered. Restarting child processes..."
+                );
                 continue;
             }
             break;
@@ -543,7 +604,10 @@ fn main() {
     } else {
         let user_path = mygestures::config::get_default_config_path();
         if !user_path.exists() {
-            eprintln!("Error: Configuration file not found at {}.", user_path.display());
+            eprintln!(
+                "Error: Configuration file not found at {}.",
+                user_path.display()
+            );
             eprintln!("Please run gestos first to initialize the configuration.");
             std::process::exit(1);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
+use crate::protractor::Point2D;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use serde::{Serialize, Deserialize};
-use crate::protractor::Point2D;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ActionType {
@@ -49,7 +49,7 @@ pub enum ActionType {
 impl ActionType {
     pub fn from_string(s: &str) -> Option<Self> {
         let s = s.trim();
-        let mut parts = s.splitn(2, |c| c == ' ' || c == '\t');
+        let mut parts = s.splitn(2, [' ', '\t']);
         let cmd = parts.next()?.to_lowercase();
         let arg = parts.next().unwrap_or("").trim().to_string();
 
@@ -101,53 +101,55 @@ impl ActionType {
             _ => None,
         }
     }
+}
 
-    pub fn to_string(&self) -> String {
+impl std::fmt::Display for ActionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ActionType::Iconify => "iconify".to_string(),
-            ActionType::Kill => "kill".to_string(),
-            ActionType::Lower => "lower".to_string(),
-            ActionType::Raise => "raise".to_string(),
-            ActionType::Maximize => "maximize".to_string(),
-            ActionType::Restore => "restore".to_string(),
-            ActionType::ToggleMaximized => "toggle-maximized".to_string(),
-            ActionType::Keypress(arg) => format!("keypress {}", arg),
-            ActionType::Execute(arg) => format!("exec {}", arg),
-            ActionType::WorkspaceLeft => "workspace-left".to_string(),
-            ActionType::WorkspaceRight => "workspace-right".to_string(),
-            ActionType::WorkspaceUp => "workspace-up".to_string(),
-            ActionType::WorkspaceDown => "workspace-down".to_string(),
-            ActionType::ShowOverview => "show-overview".to_string(),
-            ActionType::ShowAppGrid => "show-app-grid".to_string(),
+            ActionType::Iconify => write!(f, "iconify"),
+            ActionType::Kill => write!(f, "kill"),
+            ActionType::Lower => write!(f, "lower"),
+            ActionType::Raise => write!(f, "raise"),
+            ActionType::Maximize => write!(f, "maximize"),
+            ActionType::Restore => write!(f, "restore"),
+            ActionType::ToggleMaximized => write!(f, "toggle-maximized"),
+            ActionType::Keypress(arg) => write!(f, "keypress {}", arg),
+            ActionType::Execute(arg) => write!(f, "exec {}", arg),
+            ActionType::WorkspaceLeft => write!(f, "workspace-left"),
+            ActionType::WorkspaceRight => write!(f, "workspace-right"),
+            ActionType::WorkspaceUp => write!(f, "workspace-up"),
+            ActionType::WorkspaceDown => write!(f, "workspace-down"),
+            ActionType::ShowOverview => write!(f, "show-overview"),
+            ActionType::ShowAppGrid => write!(f, "show-app-grid"),
             ActionType::Click(btn) => {
                 if let Some(b) = btn {
-                    format!("click {}", b)
+                    write!(f, "click {}", b)
                 } else {
-                    "click".to_string()
+                    write!(f, "click")
                 }
             }
-            ActionType::ToggleFullscreen => "toggle-fullscreen".to_string(),
-            ActionType::ShowDesktop => "show-desktop".to_string(),
-            ActionType::LockScreen => "lock-screen".to_string(),
-            ActionType::Terminal => "terminal".to_string(),
-            ActionType::VolumeUp => "volume-up".to_string(),
-            ActionType::VolumeDown => "volume-down".to_string(),
-            ActionType::VolumeMute => "volume-mute".to_string(),
-            ActionType::MediaPlay => "media-play".to_string(),
-            ActionType::MediaNext => "media-next".to_string(),
-            ActionType::MediaPrev => "media-prev".to_string(),
-            ActionType::Www => "www".to_string(),
-            ActionType::Home => "home".to_string(),
-            ActionType::Email => "email".to_string(),
-            ActionType::Search => "search".to_string(),
-            ActionType::Calculator => "calculator".to_string(),
-            ActionType::ControlCenter => "control-center".to_string(),
-            ActionType::Logout => "logout".to_string(),
-            ActionType::Screenshot => "screenshot".to_string(),
-            ActionType::ScreenshotWindow => "screenshot-window".to_string(),
-            ActionType::ScreenshotArea => "screenshot-area".to_string(),
-            ActionType::Gnome(arg) => format!("gnome {}", arg),
-            ActionType::Abort => "abort".to_string(),
+            ActionType::ToggleFullscreen => write!(f, "toggle-fullscreen"),
+            ActionType::ShowDesktop => write!(f, "show-desktop"),
+            ActionType::LockScreen => write!(f, "lock-screen"),
+            ActionType::Terminal => write!(f, "terminal"),
+            ActionType::VolumeUp => write!(f, "volume-up"),
+            ActionType::VolumeDown => write!(f, "volume-down"),
+            ActionType::VolumeMute => write!(f, "volume-mute"),
+            ActionType::MediaPlay => write!(f, "media-play"),
+            ActionType::MediaNext => write!(f, "media-next"),
+            ActionType::MediaPrev => write!(f, "media-prev"),
+            ActionType::Www => write!(f, "www"),
+            ActionType::Home => write!(f, "home"),
+            ActionType::Email => write!(f, "email"),
+            ActionType::Search => write!(f, "search"),
+            ActionType::Calculator => write!(f, "calculator"),
+            ActionType::ControlCenter => write!(f, "control-center"),
+            ActionType::Logout => write!(f, "logout"),
+            ActionType::Screenshot => write!(f, "screenshot"),
+            ActionType::ScreenshotWindow => write!(f, "screenshot-window"),
+            ActionType::ScreenshotArea => write!(f, "screenshot-area"),
+            ActionType::Gnome(arg) => write!(f, "gnome {}", arg),
+            ActionType::Abort => write!(f, "abort"),
         }
     }
 }
@@ -162,12 +164,11 @@ pub enum ActionsVecOrString {
 impl ActionsVecOrString {
     pub fn to_actions(&self) -> Vec<ActionType> {
         match self {
-            ActionsVecOrString::Single(s) => {
-                ActionType::from_string(s).into_iter().collect()
-            }
-            ActionsVecOrString::Multiple(v) => {
-                v.iter().filter_map(|s| ActionType::from_string(s)).collect()
-            }
+            ActionsVecOrString::Single(s) => ActionType::from_string(s).into_iter().collect(),
+            ActionsVecOrString::Multiple(v) => v
+                .iter()
+                .filter_map(|s| ActionType::from_string(s))
+                .collect(),
         }
     }
 }
@@ -322,13 +323,19 @@ pub fn initialize_user_config_if_missing() -> std::io::Result<PathBuf> {
             fs::create_dir_all(parent)?;
         }
         fs::write(&user_path, &content)?;
-        println!("Initialized user configuration from template at: {}", user_path.display());
+        println!(
+            "Initialized user configuration from template at: {}",
+            user_path.display()
+        );
     } else {
         if let Some(parent) = user_path.parent() {
             fs::create_dir_all(parent)?;
         }
         fs::write(&user_path, "# MyGestures Configuration\nglobal:\n")?;
-        println!("Initialized empty user configuration at: {}", user_path.display());
+        println!(
+            "Initialized empty user configuration at: {}",
+            user_path.display()
+        );
     }
 
     Ok(user_path)
@@ -376,7 +383,9 @@ impl Configuration {
             for (name, gest_cfg) in global {
                 let actions = gest_cfg.action_expr.to_actions();
                 let is_abort = actions.contains(&ActionType::Abort);
-                let raw_movement = gest_cfg.movement_expr.unwrap_or_else(|| "0,0 0,0".to_string());
+                let raw_movement = gest_cfg
+                    .movement_expr
+                    .unwrap_or_else(|| "0,0 0,0".to_string());
                 let points = parse_points(&raw_movement);
 
                 let matched_pos = if let Some(ref id) = gest_cfg.id {
@@ -442,7 +451,9 @@ impl Configuration {
                 lines.push(format!("  \"{}\":", g.name));
                 lines.push(format!("    move: \"{}\"", g.raw_movement));
                 if !g.actions.is_empty() {
-                    let action_str = g.actions.iter()
+                    let action_str = g
+                        .actions
+                        .iter()
                         .map(|a| a.to_string())
                         .collect::<Vec<_>>()
                         .join(", ");
@@ -478,7 +489,10 @@ pub fn generate_unique_id() -> String {
         }
     }
     use std::time::{SystemTime, UNIX_EPOCH};
-    let start = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
+    let start = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
     format!("{:x}", start)
 }
 

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -15,16 +15,14 @@ pub struct DaemonIpc {
 impl DaemonIpc {
     pub fn new(device_name: &str) -> Result<Self, std::io::Error> {
         let sanitized = device_name.replace('/', "%");
-        let shm_name = format!("/mygestures_uid_{}_dev_{}", unsafe { libc::getuid() }, sanitized);
+        let shm_name = format!(
+            "/mygestures_uid_{}_dev_{}",
+            unsafe { libc::getuid() },
+            sanitized
+        );
         let c_name = CString::new(shm_name.clone()).unwrap();
 
-        let fd = unsafe {
-            libc::shm_open(
-                c_name.as_ptr(),
-                libc::O_CREAT | libc::O_RDWR,
-                0o600,
-            )
-        };
+        let fd = unsafe { libc::shm_open(c_name.as_ptr(), libc::O_CREAT | libc::O_RDWR, 0o600) };
         if fd < 0 {
             return Err(std::io::Error::last_os_error());
         }
@@ -32,7 +30,9 @@ impl DaemonIpc {
         let size = std::mem::size_of::<ShmMessage>();
         if unsafe { libc::ftruncate(fd, size as libc::off_t) } < 0 {
             let err = std::io::Error::last_os_error();
-            unsafe { libc::close(fd); }
+            unsafe {
+                libc::close(fd);
+            }
             return Err(err);
         }
 
@@ -46,7 +46,9 @@ impl DaemonIpc {
                 0,
             )
         };
-        unsafe { libc::close(fd); }
+        unsafe {
+            libc::close(fd);
+        }
 
         if ptr == libc::MAP_FAILED {
             return Err(std::io::Error::last_os_error());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod protractor;
 pub mod config;
-pub mod wayland;
-pub mod uinput;
 pub mod ipc;
+pub mod protractor;
+pub mod uinput;
+pub mod wayland;

--- a/src/protractor.rs
+++ b/src/protractor.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Point2D {
@@ -28,7 +28,11 @@ pub fn resample_path(points: &[Point2D], n: usize) -> Vec<Point2D> {
     }
 
     let len = path_length(points);
-    let interval = if len > 1e-4 { len / (n - 1) as f64 } else { 0.0 };
+    let interval = if len > 1e-4 {
+        len / (n - 1) as f64
+    } else {
+        0.0
+    };
     let mut resampled = Vec::with_capacity(n);
     resampled.push(points[0]);
 
@@ -106,7 +110,11 @@ pub fn compute_protractor_similarity(u: &[Point2D], w: &[Point2D], max_angle_rad
     if theta.abs() <= max_angle_rad {
         (a * a + b * b).sqrt()
     } else {
-        let phi = if theta > 0.0 { max_angle_rad } else { -max_angle_rad };
+        let phi = if theta > 0.0 {
+            max_angle_rad
+        } else {
+            -max_angle_rad
+        };
         a * phi.cos() + b * phi.sin()
     }
 }
@@ -129,7 +137,13 @@ fn perpendicular_distance(p: Point2D, line_start: Point2D, line_end: Point2D) ->
     (diff_x * diff_x + diff_y * diff_y).sqrt()
 }
 
-fn douglas_peucker_recursive(points: &[Point2D], start: usize, end: usize, epsilon: f64, keep: &mut [bool]) {
+fn douglas_peucker_recursive(
+    points: &[Point2D],
+    start: usize,
+    end: usize,
+    epsilon: f64,
+    keep: &mut [bool],
+) {
     if end <= start + 1 {
         return;
     }
@@ -157,8 +171,10 @@ pub fn simplify_points(points: &[Point2D], epsilon: f64) -> Vec<Point2D> {
     keep[0] = true;
     keep[points.len() - 1] = true;
     douglas_peucker_recursive(points, 0, points.len() - 1, epsilon, &mut keep);
-    
-    points.iter().enumerate()
+
+    points
+        .iter()
+        .enumerate()
         .filter(|(idx, _)| keep[*idx])
         .map(|(_, &p)| p)
         .collect()
@@ -173,16 +189,24 @@ pub fn scale_to_square(points: &mut [Point2D], size: f64) {
     let mut min_y = points[0].y;
     let mut max_y = points[0].y;
     for p in points.iter() {
-        if p.x < min_x { min_x = p.x; }
-        if p.x > max_x { max_x = p.x; }
-        if p.y < min_y { min_y = p.y; }
-        if p.y > max_y { max_y = p.y; }
+        if p.x < min_x {
+            min_x = p.x;
+        }
+        if p.x > max_x {
+            max_x = p.x;
+        }
+        if p.y < min_y {
+            min_y = p.y;
+        }
+        if p.y > max_y {
+            max_y = p.y;
+        }
     }
     let w = max_x - min_x;
     let h = max_y - min_y;
 
     let aspect_ratio = if h.abs() > 1e-6 { w / h } else { 100.0 };
-    if aspect_ratio > 5.0 || aspect_ratio < 0.2 {
+    if !(0.2..=5.0).contains(&aspect_ratio) {
         let max_dim = w.max(h);
         let scale = if max_dim > 1e-6 { size / max_dim } else { 1.0 };
         for p in points.iter_mut() {
@@ -243,19 +267,13 @@ mod tests {
 
     #[test]
     fn test_path_length() {
-        let pts = vec![
-            Point2D { x: 0.0, y: 0.0 },
-            Point2D { x: 3.0, y: 4.0 },
-        ];
+        let pts = vec![Point2D { x: 0.0, y: 0.0 }, Point2D { x: 3.0, y: 4.0 }];
         assert_eq!(path_length(&pts), 5.0);
     }
 
     #[test]
     fn test_resample_path() {
-        let pts = vec![
-            Point2D { x: 0.0, y: 0.0 },
-            Point2D { x: 10.0, y: 0.0 },
-        ];
+        let pts = vec![Point2D { x: 0.0, y: 0.0 }, Point2D { x: 10.0, y: 0.0 }];
         let resampled = resample_path(&pts, 5);
         assert_eq!(resampled.len(), 5);
         assert_eq!(resampled[0], Point2D { x: 0.0, y: 0.0 });

--- a/src/uinput.rs
+++ b/src/uinput.rs
@@ -4,14 +4,42 @@ use evdev::uinput::VirtualDevice;
 pub fn name_to_keycode(name: &str) -> Option<u16> {
     let lower = name.to_lowercase();
     match lower.as_str() {
-        "a" => Some(30), "b" => Some(48), "c" => Some(46), "d" => Some(32), "e" => Some(18),
-        "f" => Some(33), "g" => Some(34), "h" => Some(35), "i" => Some(23), "j" => Some(36),
-        "k" => Some(37), "l" => Some(38), "m" => Some(50), "n" => Some(49), "o" => Some(24),
-        "p" => Some(25), "q" => Some(16), "r" => Some(19), "s" => Some(31), "t" => Some(20),
-        "u" => Some(22), "v" => Some(47), "w" => Some(17), "x" => Some(45), "y" => Some(21),
+        "a" => Some(30),
+        "b" => Some(48),
+        "c" => Some(46),
+        "d" => Some(32),
+        "e" => Some(18),
+        "f" => Some(33),
+        "g" => Some(34),
+        "h" => Some(35),
+        "i" => Some(23),
+        "j" => Some(36),
+        "k" => Some(37),
+        "l" => Some(38),
+        "m" => Some(50),
+        "n" => Some(49),
+        "o" => Some(24),
+        "p" => Some(25),
+        "q" => Some(16),
+        "r" => Some(19),
+        "s" => Some(31),
+        "t" => Some(20),
+        "u" => Some(22),
+        "v" => Some(47),
+        "w" => Some(17),
+        "x" => Some(45),
+        "y" => Some(21),
         "z" => Some(44),
-        "0" => Some(11), "1" => Some(2), "2" => Some(3), "3" => Some(4), "4" => Some(5),
-        "5" => Some(6), "6" => Some(7), "7" => Some(8), "8" => Some(9), "9" => Some(10),
+        "0" => Some(11),
+        "1" => Some(2),
+        "2" => Some(3),
+        "3" => Some(4),
+        "4" => Some(5),
+        "5" => Some(6),
+        "6" => Some(7),
+        "7" => Some(8),
+        "8" => Some(9),
+        "9" => Some(10),
         "return" | "enter" => Some(28),
         "escape" | "esc" => Some(1),
         "backspace" => Some(14),
@@ -34,9 +62,18 @@ pub fn name_to_keycode(name: &str) -> Option<u16> {
         "alt_r" => Some(100),
         "super_l" | "super" | "win" | "meta" => Some(125),
         "super_r" => Some(126),
-        "f1" => Some(59), "f2" => Some(60), "f3" => Some(61), "f4" => Some(62),
-        "f5" => Some(63), "f6" => Some(64), "f7" => Some(65), "f8" => Some(66),
-        "f9" => Some(67), "f10" => Some(68), "f11" => Some(87), "f12" => Some(88),
+        "f1" => Some(59),
+        "f2" => Some(60),
+        "f3" => Some(61),
+        "f4" => Some(62),
+        "f5" => Some(63),
+        "f6" => Some(64),
+        "f7" => Some(65),
+        "f8" => Some(66),
+        "f9" => Some(67),
+        "f10" => Some(68),
+        "f11" => Some(87),
+        "f12" => Some(88),
         "mute" | "audiomute" | "xf86audiomute" => Some(113),
         "volumedown" | "audiolowervolume" | "xf86audiolowervolume" => Some(114),
         "volumeup" | "audioraisevolume" | "xf86audioraisevolume" => Some(115),
@@ -67,7 +104,7 @@ impl UinputDevice {
         let mut keys = evdev::AttributeSet::<evdev::KeyCode>::new();
         // Enable standard keyboard keys so virtual device can type shortcuts
         for code in 1..255 {
-            if code >= 0x110 && code <= 0x11f {
+            if (0x110..=0x11f).contains(&code) {
                 continue; // Skip mouse button range to preserve source bindings
             }
             keys.insert(evdev::KeyCode(code));
@@ -126,7 +163,7 @@ impl UinputDevice {
 
     pub fn keypress_string(&mut self, keys: &str) {
         let mut codes = Vec::new();
-        for token in keys.split(|c| c == '+' || c == ' ') {
+        for token in keys.split(['+', ' ']) {
             if token.is_empty() {
                 continue;
             }

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -1,7 +1,7 @@
+use crate::config::ActionType;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use crate::config::ActionType;
 
 #[derive(Debug, Clone, Default)]
 pub struct WaylandContext {
@@ -39,17 +39,40 @@ impl WaylandContext {
 
         // Fallback checks using pgrep if env variables are missing
         if !ctx.is_gnome && !ctx.is_kde && !ctx.is_xfce {
-            if Command::new("pgrep").arg("-x").arg("gnome-shell").stdout(Stdio::null()).status().map(|s| s.success()).unwrap_or(false) {
+            if Command::new("pgrep")
+                .arg("-x")
+                .arg("gnome-shell")
+                .stdout(Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+            {
                 ctx.is_gnome = true;
-            } else if Command::new("pgrep").arg("-x").arg("kwin_wayland").stdout(Stdio::null()).status().map(|s| s.success()).unwrap_or(false) {
+            } else if Command::new("pgrep")
+                .arg("-x")
+                .arg("kwin_wayland")
+                .stdout(Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+            {
                 ctx.is_kde = true;
-            } else if Command::new("pgrep").arg("-x").arg("xfwm4").stdout(Stdio::null()).status().map(|s| s.success()).unwrap_or(false) {
+            } else if Command::new("pgrep")
+                .arg("-x")
+                .arg("xfwm4")
+                .stdout(Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+            {
                 ctx.is_xfce = true;
             }
         }
 
         // Resolve target user UID and username (handles running as root/sudo)
-        let sudo_uid = std::env::var("SUDO_UID").ok().and_then(|s| s.parse::<u32>().ok());
+        let sudo_uid = std::env::var("SUDO_UID")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok());
         let sudo_user = std::env::var("SUDO_USER").ok();
 
         if let (Some(uid), Some(user)) = (sudo_uid, sudo_user) {
@@ -105,13 +128,14 @@ impl WaylandContext {
                     if let Ok(d_uid) = d_name.parse::<u32>() {
                         if d_uid >= 1000 {
                             let user_run_dir = PathBuf::from(format!("/run/user/{}", d_uid));
-                            
+
                             // Check Sway socket
                             if let Ok(sub_entries) = fs::read_dir(&user_run_dir) {
                                 for sub_entry in sub_entries.flatten() {
                                     let name = sub_entry.file_name().to_string_lossy().into_owned();
                                     if name.contains("sway-ipc") && name.contains(".sock") {
-                                        ctx.sway_sock = user_run_dir.join(name).to_string_lossy().into_owned();
+                                        ctx.sway_sock =
+                                            user_run_dir.join(name).to_string_lossy().into_owned();
                                         ctx.is_sway = true;
                                         break;
                                     }
@@ -124,7 +148,10 @@ impl WaylandContext {
                                 if hypr_dir.exists() {
                                     if let Ok(sub_entries) = fs::read_dir(hypr_dir) {
                                         for sub_entry in sub_entries.flatten() {
-                                            let name = sub_entry.file_name().to_string_lossy().into_owned();
+                                            let name = sub_entry
+                                                .file_name()
+                                                .to_string_lossy()
+                                                .into_owned();
                                             if name.len() >= 40 {
                                                 ctx.hypr_sig = name;
                                                 ctx.is_hypr = true;
@@ -186,7 +213,9 @@ impl WaylandContext {
             ActionType::Kill => self.run_swaymsg("kill"),
             ActionType::Maximize => self.run_swaymsg("fullscreen enable"),
             ActionType::Restore => self.run_swaymsg("fullscreen disable"),
-            ActionType::ToggleMaximized | ActionType::ToggleFullscreen => self.run_swaymsg("fullscreen toggle"),
+            ActionType::ToggleMaximized | ActionType::ToggleFullscreen => {
+                self.run_swaymsg("fullscreen toggle")
+            }
             ActionType::WorkspaceLeft => self.run_swaymsg("workspace prev_on_output"),
             ActionType::WorkspaceRight => self.run_swaymsg("workspace next_on_output"),
             ActionType::WorkspaceUp => self.run_swaymsg("workspace prev"),
@@ -220,11 +249,15 @@ impl WaylandContext {
 
     fn execute_hypr(&self, action: &ActionType, uinput_handler: &dyn Fn(&str)) {
         match action {
-            ActionType::Iconify => self.run_hyprctl("dispatch movetoworkspacesilent special:minimized"),
+            ActionType::Iconify => {
+                self.run_hyprctl("dispatch movetoworkspacesilent special:minimized")
+            }
             ActionType::Kill => self.run_hyprctl("dispatch killactive"),
             ActionType::Raise => self.run_hyprctl("dispatch alterzorder top"),
             ActionType::Lower => self.run_hyprctl("dispatch alterzorder bottom"),
-            ActionType::Maximize | ActionType::Restore | ActionType::ToggleMaximized => self.run_hyprctl("dispatch fullscreen 1"),
+            ActionType::Maximize | ActionType::Restore | ActionType::ToggleMaximized => {
+                self.run_hyprctl("dispatch fullscreen 1")
+            }
             ActionType::ToggleFullscreen => self.run_hyprctl("dispatch fullscreen 0"),
             ActionType::WorkspaceLeft => self.run_hyprctl("dispatch workspace e-1"),
             ActionType::WorkspaceRight => self.run_hyprctl("dispatch workspace e+1"),
@@ -262,35 +295,93 @@ impl WaylandContext {
             ActionType::Iconify => self.run_gnome_shortcut("minimize", "Super_L+h", uinput_handler),
             ActionType::Kill => self.run_gnome_shortcut("close", "Alt_L+F4", uinput_handler),
             ActionType::Lower => uinput_handler("Alt_L+Escape"),
-            ActionType::Maximize => self.run_gnome_shortcut("maximize", "Super_L+Up", uinput_handler),
-            ActionType::Restore => self.run_gnome_shortcut("unmaximize", "Super_L+Down", uinput_handler),
-            ActionType::ToggleMaximized => self.run_gnome_shortcut("toggle-maximized", "Alt_L+F10", uinput_handler),
-            ActionType::WorkspaceLeft => self.run_gnome_shortcut("switch-to-workspace-left", "Control_L+Alt_L+Left", uinput_handler),
-            ActionType::WorkspaceRight => self.run_gnome_shortcut("switch-to-workspace-right", "Control_L+Alt_L+Right", uinput_handler),
-            ActionType::WorkspaceUp => self.run_gnome_shortcut("switch-to-workspace-up", "Control_L+Alt_L+Up", uinput_handler),
-            ActionType::WorkspaceDown => self.run_gnome_shortcut("switch-to-workspace-down", "Control_L+Alt_L+Down", uinput_handler),
-            ActionType::ShowOverview => self.run_gnome_shortcut("toggle-overview", "Super_L", uinput_handler),
-            ActionType::ShowAppGrid => self.run_gnome_shortcut("toggle-application-view", "Super_L+a", uinput_handler),
-            ActionType::ToggleFullscreen => self.run_gnome_shortcut("toggle-fullscreen", "F11", uinput_handler),
-            ActionType::ShowDesktop => self.run_gnome_shortcut("show-desktop", "Super_L+d", uinput_handler),
-            ActionType::LockScreen => self.run_gnome_shortcut("screensaver", "Super_L+l", uinput_handler),
-            ActionType::Terminal => self.run_gnome_shortcut("terminal", "Control_L+Alt_L+t", uinput_handler),
-            ActionType::VolumeUp => self.run_gnome_shortcut("volume-up", "XF86AudioRaiseVolume", uinput_handler),
-            ActionType::VolumeDown => self.run_gnome_shortcut("volume-down", "XF86AudioLowerVolume", uinput_handler),
-            ActionType::VolumeMute => self.run_gnome_shortcut("volume-mute", "XF86AudioMute", uinput_handler),
-            ActionType::MediaPlay => self.run_gnome_shortcut("play", "XF86AudioPlay", uinput_handler),
-            ActionType::MediaNext => self.run_gnome_shortcut("next", "XF86AudioNext", uinput_handler),
-            ActionType::MediaPrev => self.run_gnome_shortcut("previous", "XF86AudioPrev", uinput_handler),
+            ActionType::Maximize => {
+                self.run_gnome_shortcut("maximize", "Super_L+Up", uinput_handler)
+            }
+            ActionType::Restore => {
+                self.run_gnome_shortcut("unmaximize", "Super_L+Down", uinput_handler)
+            }
+            ActionType::ToggleMaximized => {
+                self.run_gnome_shortcut("toggle-maximized", "Alt_L+F10", uinput_handler)
+            }
+            ActionType::WorkspaceLeft => self.run_gnome_shortcut(
+                "switch-to-workspace-left",
+                "Control_L+Alt_L+Left",
+                uinput_handler,
+            ),
+            ActionType::WorkspaceRight => self.run_gnome_shortcut(
+                "switch-to-workspace-right",
+                "Control_L+Alt_L+Right",
+                uinput_handler,
+            ),
+            ActionType::WorkspaceUp => self.run_gnome_shortcut(
+                "switch-to-workspace-up",
+                "Control_L+Alt_L+Up",
+                uinput_handler,
+            ),
+            ActionType::WorkspaceDown => self.run_gnome_shortcut(
+                "switch-to-workspace-down",
+                "Control_L+Alt_L+Down",
+                uinput_handler,
+            ),
+            ActionType::ShowOverview => {
+                self.run_gnome_shortcut("toggle-overview", "Super_L", uinput_handler)
+            }
+            ActionType::ShowAppGrid => {
+                self.run_gnome_shortcut("toggle-application-view", "Super_L+a", uinput_handler)
+            }
+            ActionType::ToggleFullscreen => {
+                self.run_gnome_shortcut("toggle-fullscreen", "F11", uinput_handler)
+            }
+            ActionType::ShowDesktop => {
+                self.run_gnome_shortcut("show-desktop", "Super_L+d", uinput_handler)
+            }
+            ActionType::LockScreen => {
+                self.run_gnome_shortcut("screensaver", "Super_L+l", uinput_handler)
+            }
+            ActionType::Terminal => {
+                self.run_gnome_shortcut("terminal", "Control_L+Alt_L+t", uinput_handler)
+            }
+            ActionType::VolumeUp => {
+                self.run_gnome_shortcut("volume-up", "XF86AudioRaiseVolume", uinput_handler)
+            }
+            ActionType::VolumeDown => {
+                self.run_gnome_shortcut("volume-down", "XF86AudioLowerVolume", uinput_handler)
+            }
+            ActionType::VolumeMute => {
+                self.run_gnome_shortcut("volume-mute", "XF86AudioMute", uinput_handler)
+            }
+            ActionType::MediaPlay => {
+                self.run_gnome_shortcut("play", "XF86AudioPlay", uinput_handler)
+            }
+            ActionType::MediaNext => {
+                self.run_gnome_shortcut("next", "XF86AudioNext", uinput_handler)
+            }
+            ActionType::MediaPrev => {
+                self.run_gnome_shortcut("previous", "XF86AudioPrev", uinput_handler)
+            }
             ActionType::Www => self.run_gnome_shortcut("www", "XF86WWW", uinput_handler),
             ActionType::Home => self.run_gnome_shortcut("home", "XF86Explorer", uinput_handler),
             ActionType::Email => self.run_gnome_shortcut("email", "XF86Mail", uinput_handler),
             ActionType::Search => self.run_gnome_shortcut("search", "XF86Search", uinput_handler),
-            ActionType::Calculator => self.run_gnome_shortcut("calculator", "XF86Calculator", uinput_handler),
-            ActionType::ControlCenter => self.run_gnome_shortcut("control-center", "XF86ControlPanel", uinput_handler),
-            ActionType::Logout => self.run_gnome_shortcut("logout", "Control_L+Alt_L+Delete", uinput_handler),
-            ActionType::Screenshot => self.run_gnome_shortcut("screenshot", "Print", uinput_handler),
-            ActionType::ScreenshotWindow => self.run_gnome_shortcut("window-screenshot", "Alt_L+Print", uinput_handler),
-            ActionType::ScreenshotArea => self.run_gnome_shortcut("area-screenshot", "Shift_L+Print", uinput_handler),
+            ActionType::Calculator => {
+                self.run_gnome_shortcut("calculator", "XF86Calculator", uinput_handler)
+            }
+            ActionType::ControlCenter => {
+                self.run_gnome_shortcut("control-center", "XF86ControlPanel", uinput_handler)
+            }
+            ActionType::Logout => {
+                self.run_gnome_shortcut("logout", "Control_L+Alt_L+Delete", uinput_handler)
+            }
+            ActionType::Screenshot => {
+                self.run_gnome_shortcut("screenshot", "Print", uinput_handler)
+            }
+            ActionType::ScreenshotWindow => {
+                self.run_gnome_shortcut("window-screenshot", "Alt_L+Print", uinput_handler)
+            }
+            ActionType::ScreenshotArea => {
+                self.run_gnome_shortcut("area-screenshot", "Shift_L+Print", uinput_handler)
+            }
             ActionType::Gnome(gkey) => {
                 self.run_gnome_shortcut(gkey, "", uinput_handler);
             }
@@ -406,10 +497,10 @@ impl WaylandContext {
             if let Some(orig_val) = self.gsettings_get(schema, key) {
                 self.gsettings_set(schema, key, "['<Super><Shift><Control><Alt>F12']");
                 std::thread::sleep(std::time::Duration::from_millis(50));
-                
+
                 uinput_handler("Super_L+Shift_L+Control_L+Alt_L+F12");
                 std::thread::sleep(std::time::Duration::from_millis(50));
-                
+
                 self.gsettings_set(schema, key, &orig_val);
                 return;
             }
@@ -469,7 +560,11 @@ impl WaylandContext {
         let cmd = format!("gsettings get {} {}", schema, key);
         let output = self.run_user_cmd_output(&cmd)?;
         let clean = output.trim().to_string();
-        if clean.is_empty() { None } else { Some(clean) }
+        if clean.is_empty() {
+            None
+        } else {
+            Some(clean)
+        }
     }
 
     fn gsettings_set(&self, schema: &str, key: &str, value: &str) {
@@ -483,7 +578,12 @@ impl WaylandContext {
 
     // Runs a command in the user session's DBUS environment
     fn run_user_cmd(&self, cmd: &str) {
-        if let Some(mut child) = self.build_user_command(cmd).stdout(Stdio::null()).stderr(Stdio::null()).spawn().ok() {
+        if let Ok(mut child) = self
+            .build_user_command(cmd)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
             let _ = child.wait();
         }
     }
@@ -504,22 +604,33 @@ impl WaylandContext {
         let current_uid = unsafe { libc::getuid() };
         let mut prefix = String::new();
 
-        let dbus_env = if Path::new(&format!("/run/user/{}/bus", self.uid)).exists() && std::env::var("DBUS_SESSION_BUS_ADDRESS").is_err() {
-            format!("DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{}/bus ", self.uid)
+        let dbus_env = if Path::new(&format!("/run/user/{}/bus", self.uid)).exists()
+            && std::env::var("DBUS_SESSION_BUS_ADDRESS").is_err()
+        {
+            format!(
+                "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/{}/bus ",
+                self.uid
+            )
         } else {
             String::new()
         };
 
         if current_uid == 0 && !self.username.is_empty() {
             if self.is_sway {
-                prefix = format!("sudo -u {} env {}XDG_RUNTIME_DIR=/run/user/{} SWAYSOCK={} ", 
-                                 self.username, dbus_env, self.uid, self.sway_sock);
+                prefix = format!(
+                    "sudo -u {} env {}XDG_RUNTIME_DIR=/run/user/{} SWAYSOCK={} ",
+                    self.username, dbus_env, self.uid, self.sway_sock
+                );
             } else if self.is_hypr {
-                prefix = format!("sudo -u {} env {}XDG_RUNTIME_DIR=/run/user/{} HYPRLAND_INSTANCE_SIGNATURE={} ", 
-                                 self.username, dbus_env, self.uid, self.hypr_sig);
+                prefix = format!(
+                    "sudo -u {} env {}XDG_RUNTIME_DIR=/run/user/{} HYPRLAND_INSTANCE_SIGNATURE={} ",
+                    self.username, dbus_env, self.uid, self.hypr_sig
+                );
             } else {
-                prefix = format!("sudo -u {} env {}XDG_RUNTIME_DIR=/run/user/{} ", 
-                                 self.username, dbus_env, self.uid);
+                prefix = format!(
+                    "sudo -u {} env {}XDG_RUNTIME_DIR=/run/user/{} ",
+                    self.username, dbus_env, self.uid
+                );
             }
         } else if !dbus_env.is_empty() {
             prefix = dbus_env;


### PR DESCRIPTION
- Replaced manual `to_string` implementation with `std::fmt::Display` trait in `src/config.rs`.
- Replaced manual char comparison with char arrays in `.split()` calls in `src/config.rs` and `src/uinput.rs`.
- Simplified bounds checking using `RangeInclusive::contains` in `src/protractor.rs` and `src/uinput.rs`.
- Replaced verbose `match` statements with `matches!` macro in `src/bin/gestos.rs`.
- Collapsed nested `if let` and `if` blocks for better readability in `src/bin/gestos.rs`.
- Fixed warnings found by running `cargo clippy`.

---
*PR created automatically by Jules for task [10570956432559477578](https://jules.google.com/task/10570956432559477578) started by @deters*