### PR TITLE
Fix RPM build by packaging missing files

### DIFF
--- a/packaging/mygestures.spec
+++ b/packaging/mygestures.spec
@@ -52,6 +52,8 @@ getent group input >/dev/null || groupadd -r input
 %{_datadir}/applications/gestos.desktop
 %{_datadir}/icons/hicolor/scalable/apps/gestos.svg
 %{_datadir}/mygestures/mygestures.yaml
+/usr/lib/systemd/user/mygestures.service
+/usr/share/dbus-1/services/org.mygestures.Daemon.service
 
 %changelog
 * Thu Jun 11 2026 Lucas Augusto Deters <lucasdeters@gmail.com> - 4.2.0-1


### PR DESCRIPTION
Adds the `mygestures.service` and `org.mygestures.Daemon.service` files to the `%files` section of the RPM spec file to fix build failures caused by unpackaged files.

---
*PR created automatically by Jules for task [5608405775553666359](https://jules.google.com/task/5608405775553666359) started by @deters*